### PR TITLE
disable url validation

### DIFF
--- a/lib/feed.js
+++ b/lib/feed.js
@@ -466,7 +466,8 @@ function RFC3339(d) {
 }
 
 function validateURL(str) {
-    return url.format(url.parse(str));
+    var parsed = url.parse(str);
+    return parsed.protocol && parsed.host;
 }
 
 module.exports = Feed;


### PR DESCRIPTION
Howdy, not sure you feel about something like this.
I found the `validateURL` function was too opinionated for my use.
I re-use URI syntax for embedded applications and often re-use the `schema` `authority`, and `host` portions of URIs in ways that can't pass validation here.

This change should ensure that the URI has protocol and host components to them, without caring too much about what kind they are.

This is a nice library, might be nifty to add tests and come up with some more options for "how strict my feed generation" should be.
