### PR TITLE
Validation fixes

### DIFF
--- a/lib/feed.js
+++ b/lib/feed.js
@@ -32,6 +32,7 @@ function Feed(options) {
             author:         options.author,
             contributor:    options.contributor,	// Atom only
             guid:           options.guid,
+            id:             options.id,
             content:        options.content,
             copyright:		options.copyright	// Atom only
         };
@@ -215,7 +216,7 @@ function atom_1_0(options) {
 
         var entry = [
             { title:        { _attr: { type: 'html' }, _cdata: entries[i].title }},
-            { id:           entries[i].link },
+            { id:           entries[i].id || entries[i].link },
             { link:         [{ _attr: { href: entries[i].link } }]},
             { updated:      RFC3339(entries[i].date) }
         ];


### PR DESCRIPTION
These are fixes for the Atom output function.

Added the ability to specify an `id` element in the feed and entries. Also removed the feed -> link element with no `rel`. I tested the output against the feed validator and it seems to go through fine now.
