### PR TITLE
additions to atom feed and validation changes

### DIFF
--- a/lib/feed.js
+++ b/lib/feed.js
@@ -11,6 +11,7 @@ function Feed(options) {
     this.description = options.description;
     this.link        = options.link;
     this.image       = options.image;
+    this.icon        = options.icon;
     this.copyright   = options.copyright;
     this.feed        = options.feed;
     this.hub         = options.hub;
@@ -29,11 +30,11 @@ function Feed(options) {
             link:           options.link,
             description:    options.description,
             date:           options.date,
+            published:      options.published,
             image:          options.image,
             author:         options.author,
             contributor:    options.contributor,	// Atom only
-            guid:           options.guid,
-            id:             options.id,
+            guid:           options.guid || options.id,
             content:        options.content,
             copyright:		options.copyright	// Atom only
         };
@@ -106,6 +107,7 @@ function atom_1_0(options) {
     /**************************************************************************
      * "feed" node: REQUIRED elements
      *************************************************************************/
+
     if(options.id == undefined)
         throw new Error('feed id is mandatory');
     else
@@ -115,12 +117,6 @@ function atom_1_0(options) {
         throw new Error('feed title is mandatory');
     else
         feed.push({ title: options.title });
-
-    if(options.link == undefined)
-        throw new Error('feed link is mandatory');
-    else
-        if(!validateURL(options.link))
-            throw new Error('invalid feed link');
 
     if(Object.prototype.toString.call(options.updated) === '[object Date]')
         feed.push({ updated: RFC3339(options.updated) });
@@ -148,15 +144,17 @@ function atom_1_0(options) {
 
     // link (rel="alternate")
     if(options.link)
-        feed.push({ link: { _attr: { rel: 'alternate', href: options.link }}});
+    	if(!validateURL(options.link))
+            throw new Error('invalid link url');
+        else
+            feed.push({ link: { _attr: { rel: 'alternate', href: options.link }}});
 
     // link (rel="self")
     if(options.feed)
-        feed.push({ link: { _attr: { rel: 'self', href: options.feed }}});
-
-    // link (rel="hub")
-    if(options.hub)
-        feed.push({ link: { _attr: { rel:'hub', href: options.hub }}});
+    	if(!validateURL(options.feed))
+            throw new Error('invalid feed url');
+        else
+            feed.push({ link: { _attr: { rel: 'self', href: options.feed }}});
 
     /**************************************************************************
      * "feed" node: optional elements
@@ -168,6 +166,9 @@ function atom_1_0(options) {
     if(options.image)
         feed.push({ logo:       options.image });
 
+    if(options.icon)
+    	feed.push({ icon:       options.icon });
+    
     if(options.copyright)
         feed.push({ rights:     options.copyright });
 
@@ -194,7 +195,6 @@ function atom_1_0(options) {
     	}
     }
     
-    // icon
 
     /**************************************************************************
      * "entry" nodes
@@ -204,30 +204,38 @@ function atom_1_0(options) {
         // entry: required elements
         // 
         if(entries[i].title == undefined)
-            throw new Error('entry need a title');
+            throw new Error('entry needs a title');
 
-        if(entries[i].link == undefined)
-            throw new Error('entry need a link');
-        else
-            if(!validateURL(entries[i].link))
-                throw new Error('invalid entry link');
+        if(entries[i].link == undefined && entries[i].content == undefined)
+            throw new Error('entry needs at least one of the following: content, link');
+
+        if(entries[i].link == undefined && entries[i].guid == undefined)
+            throw new Error('entry needs at least one of the following: guid, link');
 
         if(entries[i].date == undefined || !(entries[i].date instanceof Date))
-            throw new Error('entry need a date');
+            throw new Error('entry needs a date');
 
         var entry = [
             { title:        { _attr: { type: 'html' }, _cdata: entries[i].title }},
-            { id:           entries[i].id || entries[i].link },
-            { link:         [{ _attr: { href: entries[i].link } }]},
+            { id:           entries[i].guid || entries[i].link },
             { updated:      RFC3339(entries[i].date) }
         ];
 
         // 
         // entry: recommended elements
         // 
+        
+        // link - relative link to article
+        if (entries[i].link && !validateURL(entries[i].link))
+            throw new Error('invalid entry link');
+        else
+            entry.push({ link: { _attr: { rel: 'alternate', href: entries[i].link } }});
+
+        // summary
         if(entries[i].description)
             entry.push({ summary: { _attr: { type: 'html' }, _cdata: entries[i].description }});
 
+        // content
         if(entries[i].content)
             entry.push({ content: { _attr: { type: 'html' }, _cdata: entries[i].content }});
 
@@ -248,10 +256,6 @@ function atom_1_0(options) {
                 entry.push({ author: entryAuthor });
             }
         }
-
-        // content
-
-        // link - relative link to article
 
         //
         // entry: optional elements
@@ -278,12 +282,17 @@ function atom_1_0(options) {
         }
 
         // published
-
+        if(entries[i].published && !(entries[i].published instanceof Date))
+            throw new Error('invalid published date');
+        else
+            if(entries[i].published)
+                entry.push({ published: RFC3339(entries[i].published) });
+        
         // source
 
         // rights
         if(entries[i].copyright)
-        	entry.push({ rights: entries[i].copyright });
+            entry.push({ rights: entries[i].copyright });
 
         feed.push({ entry: entry });
     }


### PR DESCRIPTION
I was using this package in one of my projects and came across a few minor things in it which I needed to modify. I added "icon" as an option to the feed so that it can be used in addition to "image" which was already mapped to "logo" in Atom. I also added "published" to the feed entries. I made some of the validation checks more precise, such as making "link" only required when "content" is not supplied, similar with "id" which can default to "link" if not supplied explicitly.

Thanks for making this package! It was a pleasure to use!
