### PR TITLE
Added archive feed traversal links (current, prev-archive, next-archive and via)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,13 @@ Insert feed-specific information:
 ```js
 var feed = new Feed({
     title:       'Feed Title',
-    description: 'This is my personnal feed!',
-    link:        'http://example.com/',
+    description: 'This is my personal feed!',
+    link:        'http://example.com/current',
+    via:        'http://example.com/10',
+    prevArchive:        'http://example.com/9',
     image:       'http://example.com/image.png',
     copyright:   'All rights reserved 2013, John Doe',
-    updated:     new Date(2013, 06, 14),                // optional, default = today
+    updated:     new Date(2015, 05, 17),                // optional, default = today
     
     author: {
         name:    'John Doe',

--- a/lib/feed.js
+++ b/lib/feed.js
@@ -10,6 +10,10 @@ function Feed(options) {
     this.title       = options.title;
     this.description = options.description;
     this.link        = options.link;
+    this.via = options.via,
+    this.current = options.current,
+    this.nextArchive = options.nextArchive,
+    this.prevArchive = options.prevArchive,
     this.image       = options.image;
     this.copyright   = options.copyright;
     this.feed        = options.feed;
@@ -158,6 +162,23 @@ function atom_1_0(options) {
     if(options.hub)
         feed.push({ link: { _attr: { rel:'hub', href: options.hub }}});
 
+    // link (rel="via")
+    if(options.via)
+        feed.push({ link: { _attr: { rel: 'via', href: options.via }}});
+
+    // link (rel="current")
+    if(options.current)
+        feed.push({ link: { _attr: { rel: 'current', href: options.current }}});
+	
+    // link (rel="next-archive")
+    if(options.nextArchive)
+        feed.push({ link: { _attr: { rel: 'next-archive', href: options.nextArchive }}});
+
+    // link (rel="prev-archive")
+    if(options.prevArchive)
+        feed.push({ link: { _attr: { rel: 'prev-archive', href: options.prevArchive }}});
+	
+	
     /**************************************************************************
      * "feed" node: optional elements
      *************************************************************************/


### PR DESCRIPTION
Hi Jean-Philippe,

First up, great package, found it really useful.  For my use case however, I needed to add the ability traverse archive links as defined in page 4 of [RFC5005](https://tools.ietf.org/html/rfc5005#page-4).  I have made a couple of minor changes to your code base in my local fork to accommodate this behavior, so thought I would create a pull request for your consideration.

Thanks,

Roy
