### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,6 @@
   "bugs": {
     "url": "https://github.com/jpmonette/feed/issues"
   },
-  "os": [],
-  "cpu": [],
   "repository": {
     "type": "git",
     "url": "https://github.com/jpmonette/feed.git"


### PR DESCRIPTION
Leave `os` and `cpu` out since they're empty anyway. This is throwing an error with yarn.

```
error feed@0.3.0: The platform "darwin" is incompatible with this module.
error feed@0.3.0: The CPU architecture "x64" is incompatible with this module.
error Found incompatible module
```