### PR TITLE
Change html_content to content_html

### DIFF
--- a/src/__tests__/__snapshots__/json.spec.ts.snap
+++ b/src/__tests__/__snapshots__/json.spec.ts.snap
@@ -18,7 +18,7 @@ exports[`json 1 should generate a valid feed 1`] = `
     \\"items\\": [
         {
             \\"id\\": \\"https://example.com/hello-world\\",
-            \\"html_content\\": \\"Content of my item\\",
+            \\"content_html\\": \\"Content of my item\\",
             \\"url\\": \\"https://example.com/hello-world\\",
             \\"title\\": \\"Hello World\\",
             \\"summary\\": \\"This is an article about Hello World.\\",

--- a/src/json.ts
+++ b/src/json.ts
@@ -42,7 +42,7 @@ export default (ins: Feed) => {
       id: item.id,
       // json_feed distinguishes between html and text content
       // but since we only take a single type, we'll assume HTML
-      html_content: item.content
+      content_html: item.content
     };
     if (item.link) {
       feedItem.url = item.link;


### PR DESCRIPTION
The JSON feed specification https://jsonfeed.org/version/1 indicates that content should be either `content_html` or `content_text`