### PR TITLE
Features/custom namespaces and elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,51 @@ console.log(feed.json1());
 // Output: JSON Feed 1.0
 ```
 
+## Custom Namespace
+
+```js
+feed.namespaces = {
+  "xmlns:dcterms": "https://purl.org/dc/terms/",
+  "xmlns:media": "https://search.yahoo.com/mrss/"
+};
+```
+
+## Custom Elements at Root
+
+```js
+feed.elements = [{
+  'custom1': [{
+    _attr: {
+      attr1: 'value1'
+    }
+  }, {
+    'custom2': 'value2'
+  }]
+}];
+```
+
+## Custom Elements in Item
+
+```js
+posts.forEach(post => {
+  feed.addItem({
+    title: post.title,
+    id: post.url,
+    elements: [{
+      'media:content': [{
+        _attr: {
+          url: 'https://v3spec.msn.com/image1.jpg',
+          type: 'image/jpeg',
+          medium: 'image'
+        }
+      }, {
+        'media:credit': 'Joe Gargery/Fabrikam Images'
+      }]
+    }]
+  });
+});
+```
+
 ## Migrating from `< 3.0.0`
 
 If you are migrating from a version older than `3.0.0`, be sure to update your import as we migrated to ES6 named imports.

--- a/src/__tests__/__snapshots__/atom1.spec.ts.snap
+++ b/src/__tests__/__snapshots__/atom1.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`atom 1.0 should generate a valid feed 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
-<feed xmlns=\\"http://www.w3.org/2005/Atom\\">
+<feed xmlns=\\"http://www.w3.org/2005/Atom\\" xmlns:dcterms=\\"https://purl.org/dc/terms/\\" xmlns:media=\\"https://search.yahoo.com/mrss/\\">
     <id>http://example.com/</id>
     <title>Feed Title</title>
     <updated>2013-07-13T23:00:00.000Z</updated>
@@ -53,6 +53,12 @@ exports[`atom 1.0 should generate a valid feed 1`] = `
             <uri>https://example.com/reggiemiller</uri>
         </contributor>
         <published>2013-07-10T23:00:00.000Z</published>
+        <media:content url=\\"https://v3spec.msn.com/image1.jpg\\" type=\\"image/jpeg\\" medium=\\"image\\">
+            <media:credit>Joe Gargery/Fabrikam Images</media:credit>
+        </media:content>
     </entry>
+    <media:content url=\\"https://v3spec.msn.com/image1.jpg\\" type=\\"image/jpeg\\" medium=\\"image\\">
+        <media:credit>Joe Gargery/Fabrikam Images</media:credit>
+    </media:content>
 </feed>"
 `;

--- a/src/__tests__/__snapshots__/json.spec.ts.snap
+++ b/src/__tests__/__snapshots__/json.spec.ts.snap
@@ -5,6 +5,7 @@ exports[`json 1 should generate a valid feed 1`] = `
     \\"version\\": \\"https://jsonfeed.org/version/1\\",
     \\"title\\": \\"Feed Title\\",
     \\"home_page_url\\": \\"http://example.com/\\",
+    \\"feed_url\\": \\"https://example.com/json\\",
     \\"description\\": \\"This is my personnal feed!\\",
     \\"icon\\": \\"http://example.com/image.png\\",
     \\"author\\": {

--- a/src/__tests__/__snapshots__/rss2.spec.ts.snap
+++ b/src/__tests__/__snapshots__/rss2.spec.ts.snap
@@ -18,6 +18,9 @@ exports[`rss 2.0 should generate a valid feed 1`] = `
         <copyright>All rights reserved 2013, John Doe</copyright>
         <category>Technology</category>
         <atom:link href=\\"http://example.com/sampleFeed.rss\\" rel=\\"self\\" type=\\"application/rss+xml\\"/>
+        <media:content url=\\"https://v3spec.msn.com/image1.jpg\\" type=\\"image/jpeg\\" medium=\\"image\\">
+            <media:credit>Joe Gargery/Fabrikam Images</media:credit>
+        </media:content>
         <item>
             <title><![CDATA[Hello World]]></title>
             <link>https://example.com/hello-world</link>
@@ -33,9 +36,6 @@ exports[`rss 2.0 should generate a valid feed 1`] = `
                 <media:credit>Joe Gargery/Fabrikam Images</media:credit>
             </media:content>
         </item>
-        <media:content url=\\"https://v3spec.msn.com/image1.jpg\\" type=\\"image/jpeg\\" medium=\\"image\\">
-            <media:credit>Joe Gargery/Fabrikam Images</media:credit>
-        </media:content>
     </channel>
 </rss>"
 `;

--- a/src/__tests__/__snapshots__/rss2.spec.ts.snap
+++ b/src/__tests__/__snapshots__/rss2.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`rss 2.0 should generate a valid feed 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
-<rss version=\\"2.0\\" xmlns:content=\\"http://purl.org/rss/1.0/modules/content/\\" xmlns:atom=\\"http://www.w3.org/2005/Atom\\">
+<rss version=\\"2.0\\" xmlns:content=\\"http://purl.org/rss/1.0/modules/content/\\" xmlns:atom=\\"http://www.w3.org/2005/Atom\\" xmlns:dcterms=\\"https://purl.org/dc/terms/\\" xmlns:media=\\"https://search.yahoo.com/mrss/\\">
     <channel>
         <title>Feed Title</title>
         <link>http://example.com/</link>
@@ -29,7 +29,13 @@ exports[`rss 2.0 should generate a valid feed 1`] = `
             <author>joesmith@example.com (Joe Smith)</author>
             <enclosure url=\\"https://example.com/hello-world.jpg\\">
             </enclosure>
+            <media:content url=\\"https://v3spec.msn.com/image1.jpg\\" type=\\"image/jpeg\\" medium=\\"image\\">
+                <media:credit>Joe Gargery/Fabrikam Images</media:credit>
+            </media:content>
         </item>
+        <media:content url=\\"https://v3spec.msn.com/image1.jpg\\" type=\\"image/jpeg\\" medium=\\"image\\">
+            <media:credit>Joe Gargery/Fabrikam Images</media:credit>
+        </media:content>
     </channel>
 </rss>"
 `;

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -17,6 +17,11 @@ export const sampleFeed = new Feed({
     name: "John Doe",
     email: "johndoe@example.com",
     link: "https://example.com/johndoe"
+  },
+
+  feedLinks: {
+    json: "https://example.com/json",
+    atom: "https://example.com/atom"
   }
 });
 

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -76,7 +76,18 @@ sampleFeed.addItem({
   ],
   date: updated,
   image: "https://example.com/hello-world.jpg",
-  published
+  published,
+  elements: [{
+    'media:content': [{
+      _attr: {
+        url: 'https://v3spec.msn.com/image1.jpg',
+        type: 'image/jpeg',
+        medium: 'image'
+      }
+    }, {
+      'media:credit': 'Joe Gargery/Fabrikam Images'
+    }]
+  }]
 });
 
 sampleFeed.addExtension({
@@ -86,3 +97,20 @@ sampleFeed.addExtension({
     dummy: "example"
   }
 });
+
+sampleFeed.namespaces = {
+  "xmlns:dcterms": "https://purl.org/dc/terms/",
+  "xmlns:media": "https://search.yahoo.com/mrss/"
+};
+
+sampleFeed.elements = [{
+  'media:content': [{
+    _attr: {
+      url: 'https://v3spec.msn.com/image1.jpg',
+      type: 'image/jpeg',
+      medium: 'image'
+    }
+  }, {
+    'media:credit': 'Joe Gargery/Fabrikam Images'
+  }]
+}];

--- a/src/atom1.ts
+++ b/src/atom1.ts
@@ -2,6 +2,7 @@
 
 import * as xml from "xml";
 import { generator } from "./config";
+import { ifTruePush, ifTruePushArray } from './feed';
 
 const DOCTYPE = '<?xml version="1.0" encoding="utf-8"?>\n';
 
@@ -11,6 +12,11 @@ export default (ins: Feed) => {
   let feed: any = [];
 
   feed.push({ _attr: { xmlns: "http://www.w3.org/2005/Atom" } });
+
+  Object.keys(ins.namespaces).forEach(function (ns) {
+    feed[0]._attr[ns] = ins.namespaces[ns];
+  });
+
   feed.push({ id: options.id });
   feed.push({ title: options.title });
 
@@ -133,8 +139,12 @@ export default (ins: Feed) => {
       entry.push({ rights: item.copyright });
     }
 
+    ifTruePushArray(item.elements, entry);
+
     feed.push({ entry });
   });
+
+  ifTruePushArray(ins.elements, feed);
 
   return DOCTYPE + xml([{ feed }], true);
 };

--- a/src/feed.ts
+++ b/src/feed.ts
@@ -9,6 +9,8 @@ export class Feed {
   items: Item[] = [];
   categories: string[] = [];
   contributors: Author[] = [];
+  namespaces: any = {};
+  elements: any[] = [];
   extensions: Extension[] = [];
 
   constructor(options: FeedOptions) {
@@ -37,4 +39,28 @@ export class Feed {
    * Returns a JSON1 feed
    */
   public json1 = (): string => renderJSON(this);
+}
+
+export function ifTruePush(data: any, array: any) {
+  if (data) {
+    if (data.isCdata) {
+      Object.keys(data).forEach(function (key) {
+        if (key !== 'isCdata') {
+          data = {};
+          data[key] = { _cdata: data[key] };
+        }
+      });
+    }
+    array.push(data);
+  }
+}
+
+export function ifTruePushArray(dataArray: any[] | undefined, array: any) {
+  if (!dataArray) {
+    return;
+  }
+
+  dataArray.forEach(function (item) {
+    ifTruePush(item, array);
+  });
 }

--- a/src/rss2.ts
+++ b/src/rss2.ts
@@ -86,6 +86,8 @@ export default (ins: Feed) => {
     });
   }
 
+  ifTruePushArray(ins.elements, channel);
+
   /**
    * Channel Categories
    * http://cyber.law.harvard.edu/rss/rss.html#hrelementsOfLtitemgt
@@ -139,8 +141,6 @@ export default (ins: Feed) => {
 
     channel.push({ item });
   });
-
-  ifTruePushArray(ins.elements, channel);
 
   if (isContent) {
     rss[0]._attr["xmlns:content"] = "http://purl.org/rss/1.0/modules/content/";

--- a/src/rss2.ts
+++ b/src/rss2.ts
@@ -3,6 +3,7 @@
 import * as xml from "xml";
 
 import { generator } from "./config";
+import { ifTruePush, ifTruePushArray } from './feed';
 
 const DOCTYPE = '<?xml version="1.0" encoding="utf-8"?>\n';
 
@@ -134,8 +135,12 @@ export default (ins: Feed) => {
       item.push({ enclosure: [{ _attr: { url: entry.image } }] });
     }
 
+    ifTruePushArray(entry.elements, item);
+
     channel.push({ item });
   });
+
+  ifTruePushArray(ins.elements, channel);
 
   if (isContent) {
     rss[0]._attr["xmlns:content"] = "http://purl.org/rss/1.0/modules/content/";
@@ -144,6 +149,10 @@ export default (ins: Feed) => {
   if (isAtom) {
     rss[0]._attr["xmlns:atom"] = "http://www.w3.org/2005/Atom";
   }
+
+  Object.keys(ins.namespaces).forEach(function (ns) {
+    rss[0]._attr[ns] = ins.namespaces[ns];
+  });
 
   return DOCTYPE + xml([{ rss }], true);
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,6 +18,7 @@ interface Item {
   copyright?: string;
 
   extensions?: Extension[];
+  elements?: any[];
 }
 
 interface Author {
@@ -50,6 +51,8 @@ interface Feed {
   categories: string[];
   contributors: Author[];
   extensions: Extension[];
+  namespaces: any;
+  elements?: any[];
 }
 
 interface Extension {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -57,5 +57,5 @@ interface Feed {
 
 interface Extension {
   name: string;
-  objects: string;
+  objects: any;
 }


### PR DESCRIPTION
Add ability to customize namespaces and elements. This supercedes pull #69.

Examples:

Custom namespace:
```
feed.namespaces = {
  "xmlns:dcterms": "https://purl.org/dc/terms/",
  "xmlns:media": "https://search.yahoo.com/mrss/"
};
```

Custom elements at root:
```
feed.elements = [{
  'custom1': [{
    _attr: {
      attr1: 'value1'
    }
  }, {
    'custom2': 'value2'
  }]
}];
```

Custom elements in item:
```
posts.forEach(post => {
  feed.addItem({
    title: post.title,
    id: post.url,
    elements: [{
      'media:content': [{
        _attr: {
          url: 'https://v3spec.msn.com/image1.jpg',
          type: 'image/jpeg',
          medium: 'image'
        }
      }, {
        'media:credit': 'Joe Gargery/Fabrikam Images'
      }]
    }]
  });
});
```