### PR TITLE
Make `feed` option optional

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -32,7 +32,7 @@ interface FeedOptions {
   updated?: Date;
   generator?: string;
 
-  feed: string;
+  feed?: string;
   feedLinks: any;
   hub?: string;
 


### PR DESCRIPTION
This property is not mentioned at all in the README, let alone as a required parameter. Thus, I marked it as optional. Not sure if that makes sense, so feel free to reject if not :)