### PR TITLE
Update homepage to github repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "feed",
   "version": "3.0.0",
   "description": "Feed is a RSS, Atom and JSON feed generator for Node.js, making content syndication simple and intuitive!",
-  "homepage": "https://github.com/jpmonette",
+  "homepage": "https://github.com/jpmonette/feed",
   "author": "Jean-Philippe Monette <contact@jpmonette.net>",
   "license": "MIT",
   "main": "lib/feed.js",


### PR DESCRIPTION
This make it easier to click from npmjs.org

Normally the homepage is the repo, but can also be the site about the page. I normally click that link when I browse npmjs.org 😄