### PR TITLE
Change default docs url and allow override

### DIFF
--- a/src/__tests__/__snapshots__/rss2.spec.ts.snap
+++ b/src/__tests__/__snapshots__/rss2.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`rss 2.0 should generate a valid feed 1`] = `
         <link>http://example.com/</link>
         <description>This is my personnal feed!</description>
         <lastBuildDate>Sat, 13 Jul 2013 23:00:00 GMT</lastBuildDate>
-        <docs>http://blogs.law.harvard.edu/tech/rss</docs>
+        <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>https://github.com/jpmonette/feed</generator>
         <language>en</language>
         <image>

--- a/src/rss2.ts
+++ b/src/rss2.ts
@@ -17,7 +17,7 @@ export default (ins: Feed) => {
         link: { _text: options.link },
         description: { _text: options.description },
         lastBuildDate: { _text: options.updated ? options.updated.toUTCString() : new Date().toUTCString() },
-        docs: { _text: "http://blogs.law.harvard.edu/tech/rss" },
+        docs: { _text: "https://validator.w3.org/feed/docs/rss2.html" },
         generator: { _text: options.generator || generator }
       }
     }

--- a/src/rss2.ts
+++ b/src/rss2.ts
@@ -17,7 +17,7 @@ export default (ins: Feed) => {
         link: { _text: options.link },
         description: { _text: options.description },
         lastBuildDate: { _text: options.updated ? options.updated.toUTCString() : new Date().toUTCString() },
-        docs: { _text: "https://validator.w3.org/feed/docs/rss2.html" },
+        docs: { _text: options.docs ? options.docs : "https://validator.w3.org/feed/docs/rss2.html" },
         generator: { _text: options.generator || generator }
       }
     }

--- a/src/rss2.ts
+++ b/src/rss2.ts
@@ -33,7 +33,7 @@ export default (ins: Feed) => {
 
   /**
    * Channel Image
-   * http://cyber.law.harvard.edu/rss/rss.html#ltimagegtSubelementOfLtchannelgt
+   * https://validator.w3.org/feed/docs/rss2.html#ltimagegtSubelementOfLtchannelgt
    */
   if (options.image) {
     base.rss.channel.image = {
@@ -45,7 +45,7 @@ export default (ins: Feed) => {
 
   /**
    * Channel Copyright
-   * http://cyber.law.harvard.edu/rss/rss.html#optionalChannelElements
+   * https://validator.w3.org/feed/docs/rss2.html#optionalChannelElements
    */
   if (options.copyright) {
     base.rss.channel.copyright = { _text: options.copyright };
@@ -53,7 +53,7 @@ export default (ins: Feed) => {
 
   /**
    * Channel Categories
-   * http://cyber.law.harvard.edu/rss/rss.html#comments
+   * https://validator.w3.org/feed/docs/rss2.html#comments
    */
   ins.categories.map(category => {
     if (!base.rss.channel.category) {
@@ -99,7 +99,7 @@ export default (ins: Feed) => {
 
   /**
    * Channel Categories
-   * http://cyber.law.harvard.edu/rss/rss.html#hrelementsOfLtitemgt
+   * https://validator.w3.org/feed/docs/rss2.html#hrelementsOfLtitemgt
    */
   base.rss.channel.item = [];
 
@@ -134,7 +134,7 @@ export default (ins: Feed) => {
     }
     /**
      * Item Author
-     * http://cyber.law.harvard.edu/rss/rss.html#ltauthorgtSubelementOfLtitemgt
+     * https://validator.w3.org/feed/docs/rss2.html#ltauthorgtSubelementOfLtitemgt
      */
     if (Array.isArray(entry.author)) {
       item.author = [];

--- a/src/typings/index.ts
+++ b/src/typings/index.ts
@@ -36,6 +36,7 @@ export interface FeedOptions {
   feed?: string;
   feedLinks?: any;
   hub?: string;
+  docs?: string;
 
   author?: Author;
   link?: string;


### PR DESCRIPTION
This will change the default value a feeds `doc` attribute from `http://blogs.law.harvard.edu/tech/rss` to `https://validator.w3.org/feed/docs/rss2.html`. 

Both documents contain the same content, so this is a URL-only change.

I propose that this is less confusing for new users. I myself spent a few minutes wondering why my feed had a reference to a random university law blog, and assumed my content had got contaminated. 😂 

The new URL is the top result on Google for "RSS 2.0 specification" and references w3.org, which should hopefully offer a better clue to future users like me! 