### PR TITLE
Support to add categories in each items

### DIFF
--- a/src/rss2.ts
+++ b/src/rss2.ts
@@ -148,7 +148,13 @@ export default (ins: Feed) => {
     if (entry.image) {
       item.enclosure = { _attributes: { url: entry.image } };
     }
-
+    
+    if(entry.categories) {
+      entry.categories.map((singleCategory) => {
+        item.category = { _cdata: singleCategory };
+      });
+    }
+    
     base.rss.channel.item.push(item);
   });
 


### PR DESCRIPTION
It should accept categories in array format like this:

categories: ["node","php", "html"]

and render it to each item in following format
<category>
<![CDATA[node]]>
</category>