### PR TITLE
Sanitizing XML feeds

### DIFF
--- a/src/__tests__/__snapshots__/atom1.spec.ts.snap
+++ b/src/__tests__/__snapshots__/atom1.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`atom 1.0 should generate a valid feed 1`] = `
     <author>
         <name>John Doe</name>
         <email>johndoe@example.com</email>
-        <uri>https://example.com/johndoe</uri>
+        <uri>https://example.com/johndoe?link=sanitized&amp;value=2</uri>
     </author>
     <link rel=\\"alternate\\" href=\\"http://example.com/\\"/>
     <link rel=\\"self\\" href=\\"http://example.com/sampleFeed.rss\\"/>
@@ -25,15 +25,15 @@ exports[`atom 1.0 should generate a valid feed 1`] = `
     </contributor>
     <entry>
         <title type=\\"html\\"><![CDATA[Hello World]]></title>
-        <id>https://example.com/hello-world</id>
-        <link href=\\"https://example.com/hello-world\\"/>
+        <id>https://example.com/hello-world?id=this&amp;that=true</id>
+        <link href=\\"https://example.com/hello-world?link=sanitized&amp;value=2\\"/>
         <updated>2013-07-13T23:00:00.000Z</updated>
         <summary type=\\"html\\"><![CDATA[This is an article about Hello World.]]></summary>
         <content type=\\"html\\"><![CDATA[Content of my item]]></content>
         <author>
             <name>Jane Doe</name>
             <email>janedoe@example.com</email>
-            <uri>https://example.com/janedoe</uri>
+            <uri>https://example.com/janedoe?link=sanitized&amp;value=2</uri>
         </author>
         <author>
             <name>Joe Smith</name>

--- a/src/__tests__/__snapshots__/json.spec.ts.snap
+++ b/src/__tests__/__snapshots__/json.spec.ts.snap
@@ -9,7 +9,7 @@ exports[`json 1 should generate a valid feed 1`] = `
     \\"icon\\": \\"http://example.com/image.png\\",
     \\"author\\": {
         \\"name\\": \\"John Doe\\",
-        \\"url\\": \\"https://example.com/johndoe\\"
+        \\"url\\": \\"https://example.com/johndoe?link=sanitized&value=2\\"
     },
     \\"_example_extension\\": {
         \\"about\\": \\"just an extension example\\",
@@ -17,9 +17,9 @@ exports[`json 1 should generate a valid feed 1`] = `
     },
     \\"items\\": [
         {
-            \\"id\\": \\"https://example.com/hello-world\\",
+            \\"id\\": \\"https://example.com/hello-world?id=this&that=true\\",
             \\"content_html\\": \\"Content of my item\\",
-            \\"url\\": \\"https://example.com/hello-world\\",
+            \\"url\\": \\"https://example.com/hello-world?link=sanitized&value=2\\",
             \\"title\\": \\"Hello World\\",
             \\"summary\\": \\"This is an article about Hello World.\\",
             \\"image\\": \\"https://example.com/hello-world.jpg\\",
@@ -27,7 +27,7 @@ exports[`json 1 should generate a valid feed 1`] = `
             \\"date_published\\": \\"2013-07-10T23:00:00.000Z\\",
             \\"author\\": {
                 \\"name\\": \\"Jane Doe\\",
-                \\"url\\": \\"https://example.com/janedoe\\"
+                \\"url\\": \\"https://example.com/janedoe?link=sanitized&value=2\\"
             },
             \\"_item_extension_1\\": {
                 \\"about\\": \\"just an item extension example\\",

--- a/src/__tests__/__snapshots__/rss2.spec.ts.snap
+++ b/src/__tests__/__snapshots__/rss2.spec.ts.snap
@@ -21,8 +21,8 @@ exports[`rss 2.0 should generate a valid feed 1`] = `
         <atom:link href=\\"http://example.com/sampleFeed.rss\\" rel=\\"self\\" type=\\"application/rss+xml\\"/>
         <item>
             <title><![CDATA[Hello World]]></title>
-            <link>https://example.com/hello-world</link>
-            <guid>https://example.com/hello-world</guid>
+            <link>https://example.com/hello-world?link=sanitized&amp;value=2</link>
+            <guid>https://example.com/hello-world?id=this&amp;that=true</guid>
             <pubDate>Sat, 13 Jul 2013 23:00:00 GMT</pubDate>
             <description><![CDATA[This is an article about Hello World.]]></description>
             <content:encoded><![CDATA[Content of my item]]></content:encoded>

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -17,7 +17,7 @@ export const sampleFeed = new Feed({
   author: {
     name: "John Doe",
     email: "johndoe@example.com",
-    link: "https://example.com/johndoe"
+    link: "https://example.com/johndoe?link=sanitized&value=2"
   }
 });
 
@@ -31,15 +31,15 @@ sampleFeed.addContributor({
 
 sampleFeed.addItem({
   title: "Hello World",
-  id: "https://example.com/hello-world",
-  link: "https://example.com/hello-world",
+  id: "https://example.com/hello-world?id=this&that=true",
+  link: "https://example.com/hello-world?link=sanitized&value=2",
   description: "This is an article about Hello World.",
   content: "Content of my item",
   author: [
     {
       name: "Jane Doe",
       email: "janedoe@example.com",
-      link: "https://example.com/janedoe"
+      link: "https://example.com/janedoe?link=sanitized&value=2"
     },
     {
       name: "Joe Smith",

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -76,7 +76,9 @@ sampleFeed.addItem({
     }
   ],
   date: updated,
-  image: "https://example.com/hello-world.jpg",
+  image: {
+    url: "https://example.com/hello-world.jpg",
+  },
   published
 });
 

--- a/src/__tests__/utils.spec.ts
+++ b/src/__tests__/utils.spec.ts
@@ -1,0 +1,15 @@
+import { sanitize } from "../utils";
+
+describe("Sanitizing", () => {
+  it("should sanitize & to &amp;", () => {
+    expect('&amp;').toEqual(sanitize('&'));
+  });
+  it("should handle multiple &", () => {
+    expect('https://test.com/?page=1&amp;size=3&amp;length=10').toEqual(sanitize('https://test.com/?page=1&size=3&length=10'));
+  });
+
+  it("should handle undefined", () => {
+    var undefined;
+    expect(sanitize(undefined)).toBeUndefined();
+  });
+});

--- a/src/atom1.ts
+++ b/src/atom1.ts
@@ -2,6 +2,7 @@ import { generator } from "./config";
 import * as convert from "xml-js";
 import { Feed } from "./feed";
 import { Author, Item } from "./typings";
+import { sanitize } from "./utils";
 
 export default (ins: Feed) => {
   const { options } = ins;
@@ -13,7 +14,7 @@ export default (ins: Feed) => {
       id: options.id,
       title: options.title,
       updated: options.updated ? options.updated.toISOString() : new Date().toISOString(),
-      generator: options.generator || generator
+      generator: sanitize(options.generator || generator)
     }
   };
 
@@ -25,19 +26,19 @@ export default (ins: Feed) => {
 
   // link (rel="alternate")
   if (options.link) {
-    base.feed.link.push({ _attributes: { rel: "alternate", href: options.link } });
+    base.feed.link.push({ _attributes: { rel: "alternate", href: sanitize(options.link) } });
   }
 
   // link (rel="self")
-  const atomLink = options.feed || (options.feedLinks && options.feedLinks.atom);
+  const atomLink = sanitize(options.feed || (options.feedLinks && options.feedLinks.atom));
 
   if (atomLink) {
-    base.feed.link.push({ _attributes: { rel: "self", href: atomLink } });
+    base.feed.link.push({ _attributes: { rel: "self", href: sanitize(atomLink) } });
   }
 
   // link (rel="hub")
   if (options.hub) {
-    base.feed.link.push({ _attributes: { rel: "hub", href: options.hub } });
+    base.feed.link.push({ _attributes: { rel: "hub", href: sanitize(options.hub) } });
   }
 
   /**************************************************************************
@@ -86,8 +87,8 @@ export default (ins: Feed) => {
 
     let entry: convert.ElementCompact = {
       title: { _attributes: { type: "html" }, _cdata: item.title },
-      id: item.id || item.link,
-      link: [{ _attributes: { href: item.link } }],
+      id: sanitize(item.id || item.link),
+      link: [{ _attributes: { href: sanitize(item.link) } }],
       updated: item.date.toISOString()
     };
 
@@ -160,6 +161,6 @@ const formatAuthor = (author: Author) => {
   return {
     name,
     email,
-    uri: link
+    uri: sanitize(link)
   };
 };

--- a/src/json.ts
+++ b/src/json.ts
@@ -57,7 +57,7 @@ export default (ins: Feed) => {
     }
 
     if (item.image) {
-      feedItem.image = item.image;
+      feedItem.image = item.image.url;
     }
 
     if (item.date) {

--- a/src/rss2.ts
+++ b/src/rss2.ts
@@ -2,6 +2,7 @@ import * as convert from "xml-js";
 import { generator } from "./config";
 import { Feed } from "./feed";
 import { Item, Author } from "./typings";
+import { sanitize } from "./utils";
 
 export default (ins: Feed) => {
   const { options } = ins;
@@ -14,7 +15,7 @@ export default (ins: Feed) => {
       _attributes: { version: "2.0" },
       channel: {
         title: { _text: options.title },
-        link: { _text: options.link },
+        link: { _text: sanitize(options.link) },
         description: { _text: options.description },
         lastBuildDate: { _text: options.updated ? options.updated.toUTCString() : new Date().toUTCString() },
         docs: { _text: options.docs ? options.docs : "https://validator.w3.org/feed/docs/rss2.html" },
@@ -39,7 +40,7 @@ export default (ins: Feed) => {
     base.rss.channel.image = {
       title: { _text: options.title },
       url: { _text: options.image },
-      link: { _text: options.link }
+      link: { _text: sanitize(options.link) }
     };
   }
 
@@ -72,7 +73,7 @@ export default (ins: Feed) => {
     base.rss.channel["atom:link"] = [
       {
         _attributes: {
-          href: atomLink,
+          href: sanitize(atomLink),
           rel: "self",
           type: "application/rss+xml"
         }
@@ -91,7 +92,7 @@ export default (ins: Feed) => {
     }
     base.rss.channel["atom:link"] = {
       _attributes: {
-        href: options.hub,
+        href: sanitize(options.hub),
         rel: "hub"
       }
     };
@@ -111,13 +112,13 @@ export default (ins: Feed) => {
     }
 
     if (entry.link) {
-      item.link = { _text: entry.link };
+      item.link = { _text: sanitize(entry.link) };
     }
 
-    if (entry.guid) {
-      item.guid = { _text: entry.guid };
+    if (entry.id) {
+      item.guid = { _text: sanitize(entry.id) };
     } else if (entry.link) {
-      item.guid = { _text: entry.link };
+      item.guid = { _text: sanitize(entry.link) };
     }
 
     if (entry.date) {

--- a/src/rss2.ts
+++ b/src/rss2.ts
@@ -147,7 +147,7 @@ export default (ins: Feed) => {
     }
 
     if (entry.image) {
-      item.enclosure = { _attributes: { url: entry.image } };
+      item.enclosure = { _attributes: { url: entry.image.url, type: entry.image.type, length: entry.image.size } };
     }
 
     base.rss.channel.item.push(item);

--- a/src/typings/index.ts
+++ b/src/typings/index.ts
@@ -9,7 +9,7 @@ export interface Item {
 
   guid?: string;
 
-  image?: string;
+  image?: Image;
 
   author?: Author[];
   contributor?: Author[];
@@ -18,6 +18,12 @@ export interface Item {
   copyright?: string;
 
   extensions?: Extension[];
+}
+
+export interface Image {
+  url: string;
+  size?: number;
+  type?: string;
 }
 
 export interface Author {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,6 @@
+export function sanitize(url: String | undefined): String | undefined {
+  if (typeof (url) === 'undefined') {
+    return;
+  }
+  return url.replace(/&/g, '&amp;');
+}


### PR DESCRIPTION
Since XML feeds need to sanitize their output to be valid XML, it should be handled by default by `feed`. The option to sanitize the values in the `js-xml` library is deprecated (probably because of performance improvements by not search-replacing _everything_).

This also now adds the possibility to add content type and length to items, something tried to add [here](https://github.com/jpmonette/feed/pull/100) but was aborted for some reason.

Since the current implementation of RSS1 and RSS2 is not validating according to W3C it would be very much appreciated if this could be reviewed and expedited rather quickly.