### PR TITLE
Fix RSS ignoring item.id

### DIFF
--- a/src/__tests__/__snapshots__/atom1.spec.ts.snap
+++ b/src/__tests__/__snapshots__/atom1.spec.ts.snap
@@ -25,7 +25,7 @@ exports[`atom 1.0 should generate a valid feed 1`] = `
     </contributor>
     <entry>
         <title type=\\"html\\"><![CDATA[Hello World]]></title>
-        <id>https://example.com/hello-world</id>
+        <id>419c523a-28f4-489c-877e-9604be64c002</id>
         <link href=\\"https://example.com/hello-world\\"/>
         <updated>2013-07-13T23:00:00.000Z</updated>
         <summary type=\\"html\\"><![CDATA[This is an article about Hello World.]]></summary>

--- a/src/__tests__/__snapshots__/json.spec.ts.snap
+++ b/src/__tests__/__snapshots__/json.spec.ts.snap
@@ -17,7 +17,7 @@ exports[`json 1 should generate a valid feed 1`] = `
     },
     \\"items\\": [
         {
-            \\"id\\": \\"https://example.com/hello-world\\",
+            \\"id\\": \\"419c523a-28f4-489c-877e-9604be64c002\\",
             \\"content_html\\": \\"Content of my item\\",
             \\"url\\": \\"https://example.com/hello-world\\",
             \\"title\\": \\"Hello World\\",

--- a/src/__tests__/__snapshots__/rss2.spec.ts.snap
+++ b/src/__tests__/__snapshots__/rss2.spec.ts.snap
@@ -22,7 +22,7 @@ exports[`rss 2.0 should generate a valid feed 1`] = `
         <item>
             <title><![CDATA[Hello World]]></title>
             <link>https://example.com/hello-world</link>
-            <guid>https://example.com/hello-world</guid>
+            <guid>419c523a-28f4-489c-877e-9604be64c002</guid>
             <pubDate>Sat, 13 Jul 2013 23:00:00 GMT</pubDate>
             <description><![CDATA[This is an article about Hello World.]]></description>
             <content:encoded><![CDATA[Content of my item]]></content:encoded>

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -31,7 +31,7 @@ sampleFeed.addContributor({
 
 sampleFeed.addItem({
   title: "Hello World",
-  id: "https://example.com/hello-world",
+  id: "419c523a-28f4-489c-877e-9604be64c002",
   link: "https://example.com/hello-world",
   description: "This is an article about Hello World.",
   content: "Content of my item",

--- a/src/rss2.ts
+++ b/src/rss2.ts
@@ -116,6 +116,8 @@ export default (ins: Feed) => {
 
     if (entry.guid) {
       item.guid = { _text: entry.guid };
+    } else if (entry.id) {
+      item.guid = { _text: entry.id };
     } else if (entry.link) {
       item.guid = { _text: entry.link };
     }


### PR DESCRIPTION
Fixes #96 with the code that @KnicKnic recommended. This keeps backward-compatibility, and also makes `item.id` work as documented.