### PR TITLE
Item category for all feed types

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "lib/feed.js",
   "types": "lib/feed.d.ts",
   "scripts": {
-    "build": "rm -rf lib/ && mkdir lib && tsc",
+    "build": "rimraf lib/ && mkdir lib && tsc",
     "prepublish": "npm run build",
     "test": "export NODE_ENV=test && jest --silent",
     "test-travis": "export NODE_ENV=test && jest --coverage"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feed",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Feed is a RSS, Atom and JSON feed generator for Node.js, making content syndication simple and intuitive!",
   "homepage": "https://github.com/jpmonette/feed",
   "author": "Jean-Philippe Monette <contact@jpmonette.net>",

--- a/src/__tests__/__snapshots__/atom1.spec.ts.snap
+++ b/src/__tests__/__snapshots__/atom1.spec.ts.snap
@@ -40,6 +40,8 @@ exports[`atom 1.0 should generate a valid feed 1`] = `
             <email>joesmith@example.com</email>
             <uri>https://example.com/joesmith</uri>
         </author>
+        <category label=\\"Grateful Dead\\"/>
+        <category label=\\"MSFT\\"/>
         <contributor>
             <name>Shawn Kemp</name>
             <email>shawnkemp@example.com</email>

--- a/src/__tests__/__snapshots__/json.spec.ts.snap
+++ b/src/__tests__/__snapshots__/json.spec.ts.snap
@@ -29,6 +29,10 @@ exports[`json 1 should generate a valid feed 1`] = `
                 \\"name\\": \\"Jane Doe\\",
                 \\"url\\": \\"https://example.com/janedoe\\"
             },
+            \\"tags\\": [
+                \\"Grateful Dead\\",
+                \\"MSFT\\"
+            ],
             \\"_item_extension_1\\": {
                 \\"about\\": \\"just an item extension example\\",
                 \\"dummy1\\": \\"example\\"

--- a/src/__tests__/__snapshots__/rss2.spec.ts.snap
+++ b/src/__tests__/__snapshots__/rss2.spec.ts.snap
@@ -28,6 +28,8 @@ exports[`rss 2.0 should generate a valid feed 1`] = `
             <content:encoded><![CDATA[Content of my item]]></content:encoded>
             <author>janedoe@example.com (Jane Doe)</author>
             <author>joesmith@example.com (Joe Smith)</author>
+            <category>Grateful Dead</category>
+            <category domain=\\"http://www.fool.com/cusips\\">MSFT</category>
             <enclosure url=\\"https://example.com/hello-world.jpg\\"/>
         </item>
     </channel>

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -75,6 +75,15 @@ sampleFeed.addItem({
       }
     }
   ],
+  category: [
+    {
+      name: 'Grateful Dead'
+    },
+    {
+      name: 'MSFT',
+      domain: 'http://www.fool.com/cusips'
+    }
+  ],
   date: updated,
   image: "https://example.com/hello-world.jpg",
   published

--- a/src/atom1.ts
+++ b/src/atom1.ts
@@ -1,7 +1,7 @@
 import { generator } from "./config";
 import * as convert from "xml-js";
 import { Feed } from "./feed";
-import { Author, Item } from "./typings";
+import { Author, Item, Category } from "./typings";
 
 export default (ins: Feed) => {
   const { options } = ins;
@@ -126,6 +126,13 @@ export default (ins: Feed) => {
     //
 
     // category
+    if (Array.isArray(item.category)) {
+      entry.category = [];
+
+      item.category.map((category: Category) => {
+        entry.category.push(formatCategory(category));
+      });
+    }
 
     // contributor
     if (item.contributor && Array.isArray(item.contributor)) {
@@ -161,5 +168,17 @@ const formatAuthor = (author: Author) => {
     name,
     email,
     uri: link
+  };
+};
+
+const formatCategory = (category: Category) => {
+  const { name, scheme, term } = category;
+
+  return {
+    _attributes: {
+      label: name,
+      scheme,
+      term
+    }
   };
 };

--- a/src/json.ts
+++ b/src/json.ts
@@ -1,4 +1,4 @@
-import { Extension, Item, Author } from "./typings";
+import { Extension, Item, Author, Category } from "./typings";
 import { Feed } from "./feed";
 
 export default (ins: Feed) => {
@@ -80,6 +80,15 @@ export default (ins: Feed) => {
       if (author.link) {
         feedItem.author.url = author.link;
       }
+    }
+
+    if (Array.isArray(item.category)) {
+      feedItem.tags = [];
+      item.category.map((category: Category) => {
+        if (category.name) {
+          feedItem.tags.push(category.name);
+        }
+      });
     }
 
     if (item.extensions) {

--- a/src/rss2.ts
+++ b/src/rss2.ts
@@ -1,7 +1,7 @@
 import * as convert from "xml-js";
 import { generator } from "./config";
 import { Feed } from "./feed";
-import { Item, Author } from "./typings";
+import { Item, Author, Category } from "./typings";
 
 export default (ins: Feed) => {
   const { options } = ins;
@@ -146,6 +146,16 @@ export default (ins: Feed) => {
         }
       });
     }
+    /**
+     * Item Category
+     * https://validator.w3.org/feed/docs/rss2.html#ltcategorygtSubelementOfLtitemgt
+     */
+    if (Array.isArray(entry.category)) {
+      item.category = [];
+      entry.category.map((category: Category) => {
+        item.category.push(formatCategory(category));
+      });
+    }
 
     if (entry.image) {
       item.enclosure = { _attributes: { url: entry.image } };
@@ -163,3 +173,14 @@ export default (ins: Feed) => {
   }
   return convert.js2xml(base, { compact: true, ignoreComment: true, spaces: 4 });
 };
+
+const formatCategory = (category: Category) => {
+  const { name, domain } = category;
+  return {
+    _text: name,
+    _attributes: {
+      domain
+    }
+  };
+};
+

--- a/src/typings/index.ts
+++ b/src/typings/index.ts
@@ -6,6 +6,7 @@ export interface Item {
 
   description?: string;
   content?: string;
+  category?: Category[];
 
   guid?: string;
 
@@ -24,6 +25,13 @@ export interface Author {
   name?: string;
   email?: string;
   link?: string;
+}
+
+export interface Category {
+  name?: string;
+  domain?: string;
+  scheme?: string;
+  term?: string;
 }
 
 export interface FeedOptions {


### PR DESCRIPTION
Added support for an optional RSS and Atom item element(s) _category_ and JSON _tags_ array of strings. Include `category` array for a feed item. Atom's _scheme_ and _term_ attributes supported too.

Tests updated. Changed `rm -rf` to `rimraf` to make building possible on windows environments too.
