### PR TITLE
fix: export types from feed

### DIFF
--- a/src/feed.ts
+++ b/src/feed.ts
@@ -3,6 +3,8 @@ import renderJSON from "./json";
 import renderRSS from "./rss2";
 import { Author, Extension, FeedOptions, Item } from "./typings";
 
+export { Author, Extension, FeedOptions, Item };
+
 /**
  * Class used to generate Feeds
  */


### PR DESCRIPTION
Closes: #128

Export types directly from `feed`. This way it's easier to access them.