### PR TITLE
expose a method to set updated date of feed

### DIFF
--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -18,7 +18,6 @@ export const sampleFeed = new Feed({
   favicon: "http://example.com/image.ico",
   copyright: "All rights reserved 2013, John Doe",
   hub: "wss://example.com/",
-  updated, // optional, default = today
 
   author: {
     name: "John Doe",
@@ -106,3 +105,5 @@ sampleFeed.addExtension({
     dummy: "example",
   },
 });
+
+sampleFeed.setUpdated(updated);

--- a/src/feed.ts
+++ b/src/feed.ts
@@ -44,6 +44,12 @@ export class Feed {
   public addExtension = (extension: Extension) => this.extensions.push(extension);
 
   /**
+   * Set updated of a feed
+   * @param date
+   */
+  public setUpdated = (date: Date) => this.options.updated = date;
+
+  /**
    * Returns a Atom 1.0 feed
    */
   public atom1 = (): string => renderAtom(this);


### PR DESCRIPTION
Sometimes it's necessary that the "updated" field of the feed needs to be updated, like adding New Item or so.
So I exposed a new method so that the "updated" field is possible to be updated.