### PR TITLE
Fix double escaping of & in Atom feed "self" URL

### DIFF
--- a/src/__tests__/__snapshots__/atom1.spec.ts.snap
+++ b/src/__tests__/__snapshots__/atom1.spec.ts.snap
@@ -13,7 +13,7 @@ exports[`atom 1.0 should generate a valid feed 1`] = `
         <uri>https://example.com/johndoe?link=sanitized&amp;value=2</uri>
     </author>
     <link rel=\\"alternate\\" href=\\"http://example.com/\\"/>
-    <link rel=\\"self\\" href=\\"http://example.com/sampleFeed.rss\\"/>
+    <link rel=\\"self\\" href=\\"http://example.com/sampleFeed.rss?link=sanitized&amp;value=2\\"/>
     <link rel=\\"hub\\" href=\\"wss://example.com/\\"/>
     <subtitle>This is my personnal feed!</subtitle>
     <logo>http://example.com/image.png</logo>

--- a/src/__tests__/__snapshots__/atom1.spec.ts.snap
+++ b/src/__tests__/__snapshots__/atom1.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`atom 1.0 should generate a valid feed 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
 <feed xmlns=\\"http://www.w3.org/2005/Atom\\">
-    <id>http://example.com/</id>
+    <id>http://example.com/?link=sanitized&amp;value=4</id>
     <title>Feed Title</title>
     <updated>2013-07-13T23:00:00.000Z</updated>
     <generator>https://github.com/jpmonette/feed</generator>
@@ -12,12 +12,12 @@ exports[`atom 1.0 should generate a valid feed 1`] = `
         <email>johndoe@example.com</email>
         <uri>https://example.com/johndoe?link=sanitized&amp;value=2</uri>
     </author>
-    <link rel=\\"alternate\\" href=\\"http://example.com/\\"/>
+    <link rel=\\"alternate\\" href=\\"http://example.com/?link=sanitized&amp;value=3\\"/>
     <link rel=\\"self\\" href=\\"http://example.com/sampleFeed.rss?link=sanitized&amp;value=2\\"/>
     <link rel=\\"hub\\" href=\\"wss://example.com/\\"/>
     <subtitle>This is my personnal feed!</subtitle>
-    <logo>http://example.com/image.png</logo>
-    <icon>http://example.com/image.ico</icon>
+    <logo>http://example.com/image.png?link=sanitized&amp;value=6</logo>
+    <icon>http://example.com/image.ico?link=sanitized&amp;value=7</icon>
     <rights>All rights reserved 2013, John Doe</rights>
     <category term=\\"Technology\\"/>
     <contributor>

--- a/src/__tests__/__snapshots__/json.spec.ts.snap
+++ b/src/__tests__/__snapshots__/json.spec.ts.snap
@@ -4,10 +4,10 @@ exports[`json 1 should generate a valid feed 1`] = `
 "{
     \\"version\\": \\"https://jsonfeed.org/version/1\\",
     \\"title\\": \\"Feed Title\\",
-    \\"home_page_url\\": \\"http://example.com/\\",
-    \\"feed_url\\": \\"http://example.com/sampleFeed.json\\",
+    \\"home_page_url\\": \\"http://example.com/?link=sanitized&value=3\\",
+    \\"feed_url\\": \\"http://example.com/sampleFeed.json?link=sanitized&value=5\\",
     \\"description\\": \\"This is my personnal feed!\\",
-    \\"icon\\": \\"http://example.com/image.png\\",
+    \\"icon\\": \\"http://example.com/image.png?link=sanitized&value=6\\",
     \\"author\\": {
         \\"name\\": \\"John Doe\\",
         \\"url\\": \\"https://example.com/johndoe?link=sanitized&value=2\\"

--- a/src/__tests__/__snapshots__/rss2.spec.ts.snap
+++ b/src/__tests__/__snapshots__/rss2.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`rss 2.0 should generate a valid feed 1`] = `
 <rss version=\\"2.0\\" xmlns:dc=\\"http://purl.org/dc/elements/1.1/\\" xmlns:content=\\"http://purl.org/rss/1.0/modules/content/\\" xmlns:atom=\\"http://www.w3.org/2005/Atom\\">
     <channel>
         <title>Feed Title</title>
-        <link>http://example.com/</link>
+        <link>http://example.com/?link=sanitized&amp;value=3</link>
         <description>This is my personnal feed!</description>
         <lastBuildDate>Sat, 13 Jul 2013 23:00:00 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
@@ -14,8 +14,8 @@ exports[`rss 2.0 should generate a valid feed 1`] = `
         <ttl>60</ttl>
         <image>
             <title>Feed Title</title>
-            <url>http://example.com/image.png</url>
-            <link>http://example.com/</link>
+            <url>http://example.com/image.png?link=sanitized&amp;value=6</url>
+            <link>http://example.com/?link=sanitized&amp;value=3</link>
         </image>
         <copyright>All rights reserved 2013, John Doe</copyright>
         <category>Technology</category>
@@ -42,7 +42,7 @@ exports[`rss 2.0 should generate a valid feed with audio 1`] = `
 <rss version=\\"2.0\\" xmlns:dc=\\"http://purl.org/dc/elements/1.1/\\" xmlns:content=\\"http://purl.org/rss/1.0/modules/content/\\" xmlns:atom=\\"http://www.w3.org/2005/Atom\\">
     <channel>
         <title>Feed Title</title>
-        <link>http://example.com/</link>
+        <link>http://example.com/?link=sanitized&amp;value=3</link>
         <description>This is my personnal feed!</description>
         <lastBuildDate>Sat, 13 Jul 2013 23:00:00 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
@@ -51,8 +51,8 @@ exports[`rss 2.0 should generate a valid feed with audio 1`] = `
         <ttl>60</ttl>
         <image>
             <title>Feed Title</title>
-            <url>http://example.com/image.png</url>
-            <link>http://example.com/</link>
+            <url>http://example.com/image.png?link=sanitized&amp;value=6</url>
+            <link>http://example.com/?link=sanitized&amp;value=3</link>
         </image>
         <copyright>All rights reserved 2013, John Doe</copyright>
         <category>Technology</category>
@@ -118,7 +118,7 @@ exports[`rss 2.0 should generate a valid feed with enclosure 1`] = `
 <rss version=\\"2.0\\" xmlns:dc=\\"http://purl.org/dc/elements/1.1/\\" xmlns:content=\\"http://purl.org/rss/1.0/modules/content/\\" xmlns:atom=\\"http://www.w3.org/2005/Atom\\">
     <channel>
         <title>Feed Title</title>
-        <link>http://example.com/</link>
+        <link>http://example.com/?link=sanitized&amp;value=3</link>
         <description>This is my personnal feed!</description>
         <lastBuildDate>Sat, 13 Jul 2013 23:00:00 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
@@ -127,8 +127,8 @@ exports[`rss 2.0 should generate a valid feed with enclosure 1`] = `
         <ttl>60</ttl>
         <image>
             <title>Feed Title</title>
-            <url>http://example.com/image.png</url>
-            <link>http://example.com/</link>
+            <url>http://example.com/image.png?link=sanitized&amp;value=6</url>
+            <link>http://example.com/?link=sanitized&amp;value=3</link>
         </image>
         <copyright>All rights reserved 2013, John Doe</copyright>
         <category>Technology</category>
@@ -181,7 +181,7 @@ exports[`rss 2.0 should generate a valid feed with image properties 1`] = `
 <rss version=\\"2.0\\" xmlns:dc=\\"http://purl.org/dc/elements/1.1/\\" xmlns:content=\\"http://purl.org/rss/1.0/modules/content/\\" xmlns:atom=\\"http://www.w3.org/2005/Atom\\">
     <channel>
         <title>Feed Title</title>
-        <link>http://example.com/</link>
+        <link>http://example.com/?link=sanitized&amp;value=3</link>
         <description>This is my personnal feed!</description>
         <lastBuildDate>Sat, 13 Jul 2013 23:00:00 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
@@ -190,8 +190,8 @@ exports[`rss 2.0 should generate a valid feed with image properties 1`] = `
         <ttl>60</ttl>
         <image>
             <title>Feed Title</title>
-            <url>http://example.com/image.png</url>
-            <link>http://example.com/</link>
+            <url>http://example.com/image.png?link=sanitized&amp;value=6</url>
+            <link>http://example.com/?link=sanitized&amp;value=3</link>
         </image>
         <copyright>All rights reserved 2013, John Doe</copyright>
         <category>Technology</category>

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -6,16 +6,16 @@ export const published = new Date("Sat, 10 Jul 2013 23:00:00 GMT");
 export const sampleFeed = new Feed({
   title: "Feed Title",
   description: "This is my personnal feed!",
-  link: "http://example.com/",
-  id: "http://example.com/",
+  link: "http://example.com/?link=sanitized&value=3",
+  id: "http://example.com/?link=sanitized&value=4",
   feed: "http://example.com/sampleFeed.rss?link=sanitized&value=2",
   feedLinks: {
-    json: "http://example.com/sampleFeed.json",
+    json: "http://example.com/sampleFeed.json?link=sanitized&value=5",
   },
   language: "en",
   ttl: 60,
-  image: "http://example.com/image.png",
-  favicon: "http://example.com/image.ico",
+  image: "http://example.com/image.png?link=sanitized&value=6",
+  favicon: "http://example.com/image.ico?link=sanitized&value=7",
   copyright: "All rights reserved 2013, John Doe",
   hub: "wss://example.com/",
   updated, // optional, default = today

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -8,7 +8,7 @@ export const sampleFeed = new Feed({
   description: "This is my personnal feed!",
   link: "http://example.com/",
   id: "http://example.com/",
-  feed: "http://example.com/sampleFeed.rss",
+  feed: "http://example.com/sampleFeed.rss?link=sanitized&value=2",
   feedLinks: {
     json: "http://example.com/sampleFeed.json",
   },

--- a/src/atom1.ts
+++ b/src/atom1.ts
@@ -34,7 +34,7 @@ export default (ins: Feed) => {
   }
 
   // link (rel="self")
-  const atomLink = sanitize(options.feed || (options.feedLinks && options.feedLinks.atom));
+  const atomLink = options.feed || (options.feedLinks && options.feedLinks.atom);
 
   if (atomLink) {
     base.feed.link.push({ _attributes: { rel: "self", href: sanitize(atomLink) } });


### PR DESCRIPTION
In the `<link rel="self">` URL of an Atom 1 feed, a `&` in the URL is mistakenly escaped twice, appearing as `&amp;amp;`.

**Steps to reproduce:**
```
node -e 'const Feed = require("feed").Feed; console.log((new Feed({feed: "a&b"})).atom1());'
```

**Expected result:**
```xml
<?xml version="1.0" encoding="utf-8"?>
<feed xmlns="http://www.w3.org/2005/Atom">
    <id/>
    <title/>
    <updated>2021-03-05T21:19:20.314Z</updated>
    <generator>https://github.com/jpmonette/feed</generator>
    <link rel="self" href="a&amp;b"/>
</feed>
```

**Actual result:**
```xml
<?xml version="1.0" encoding="utf-8"?>
<feed xmlns="http://www.w3.org/2005/Atom">
    <id/>
    <title/>
    <updated>2021-03-05T21:16:48.247Z</updated>
    <generator>https://github.com/jpmonette/feed</generator>
    <link rel="self" href="a&amp;amp;b"/>
</feed>
```

The cause is that 50ed093a0b3dd6696b9bc5d206c9613c9f8b1f10 was overzealous, feeding `atomLink` through `sanitize()` twice.

The attached commits add a currently failing test as well as fix. Also, a few tests for the same thing in other URL-typed fields, but these were already handled correctly.