### PR TITLE
Add support for xml:base in Atom 1.0

### DIFF
--- a/src/__tests__/__snapshots__/atom1.spec.ts.snap
+++ b/src/__tests__/__snapshots__/atom1.spec.ts.snap
@@ -31,7 +31,7 @@ exports[`atom 1.0 should generate a valid feed 1`] = `
         <link href=\\"https://example.com/hello-world?link=sanitized&amp;value=2\\"/>
         <updated>2013-07-13T23:00:00.000Z</updated>
         <summary type=\\"html\\"><![CDATA[This is an article about Hello World.]]></summary>
-        <content type=\\"html\\"><![CDATA[Content of my item]]></content>
+        <content type=\\"html\\" xml:base=\\"https://example.com/base/\\"><![CDATA[Content of my item]]></content>
         <author>
             <name>Jane Doe</name>
             <email>janedoe@example.com</email>

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -97,6 +97,7 @@ sampleFeed.addItem({
   image: "https://example.com/hello-world.jpg",
   enclosure: { url: "https://example.com/hello-world.jpg", length: 12665, type: "image/jpeg" },
   published,
+  baseUrl: "https://example.com/base/",
 });
 
 sampleFeed.addExtension({

--- a/src/atom1.ts
+++ b/src/atom1.ts
@@ -111,6 +111,9 @@ export default (ins: Feed) => {
         _attributes: { type: "html" },
         _cdata: item.content,
       };
+      if (item.baseUrl) {
+        entry.content._attributes["xml:base"] = item.baseUrl;
+      }
     }
 
     // entry author(s)

--- a/src/typings/index.ts
+++ b/src/typings/index.ts
@@ -22,6 +22,8 @@ export interface Item {
   copyright?: string;
 
   extensions?: Extension[];
+
+  baseUrl?: string;
 }
 
 export interface Enclosure {


### PR DESCRIPTION
Unfortunately [RSS 2.0](https://intertwingly.net/wiki/pie/Rss20AndAtom10Compared#u) and JSON Feed do not have an equivalent, but [Atom 1.0 allows specifying a base URL](https://datatracker.ietf.org/doc/html/rfc4287#page-4) that relative URLs inside the feed item's content are relative to. I'm not sure if you're open to features only supported by a subset of the serialisations (although support for JSON Feed's extensions implies so), so feel free to reject.