### PR TITLE
Fallback to description when content is not provided for JSON feed

### DIFF
--- a/src/json.ts
+++ b/src/json.ts
@@ -48,7 +48,7 @@ export default (ins: Feed) => {
       id: item.id,
       // json_feed distinguishes between html and text content
       // but since we only take a single type, we'll assume HTML
-      content_html: item.content,
+      content_html: item.content ?? item.description,
     };
     if (item.link) {
       feedItem.url = item.link;
@@ -56,7 +56,7 @@ export default (ins: Feed) => {
     if (item.title) {
       feedItem.title = item.title;
     }
-    if (item.description) {
+    if (item.description && item.content) {
       feedItem.summary = item.description;
     }
 


### PR DESCRIPTION
In RSS 2 the description may contain the full text and the content can be omitted when there is not a short version available: https://cyber.harvard.edu/rss/rss.html#hrelementsOfLtitemgt

However a JSON feed will not contain a `content_html` field when the content is not provided.

This makes it hard to create both a JSON feed and an RSS 2 feed because providing content without a description will create a `content:encoded` field but not a `description` field in the RSS 2 feed.

My solution to this is to fallback to the `item.description` when `item.content` is not provided and generating a JSON feed.