### PR TITLE
Use cross-env for Windows compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "build": "rimraf lib/ && mkdir lib && tsc",
     "prepublish": "npm run build",
-    "test": "export NODE_ENV=test && jest --silent",
-    "test-travis": "export NODE_ENV=test && jest --coverage"
+    "test": "cross-env NODE_ENV=test && jest --silent",
+    "test-travis": "cross-env NODE_ENV=test && jest --coverage"
   },
   "keywords": [
     "rss",
@@ -29,6 +29,7 @@
     "@types/jest": "^26.0.14",
     "codeclimate-test-reporter": "^0.5.1",
     "coveralls": "^3.1.0",
+    "cross-env": "^7.0.3",
     "jest": "^26.5.3",
     "prettier": "^2.1.2",
     "source-map-loader": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1099,6 +1099,13 @@ coveralls@^3.1.0:
     minimist "^1.2.5"
     request "^2.88.2"
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -1110,7 +1117,7 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
Right now the tests don't run on Windows because of the use of export.

`cross-env` is a well-known package that takes care of this and allows the tests to work on Windows as well.