### PR TITLE
Implement "isPermaLink" for item:guid

### DIFF
--- a/src/__tests__/__snapshots__/atom1.spec.ts.snap
+++ b/src/__tests__/__snapshots__/atom1.spec.ts.snap
@@ -59,5 +59,14 @@ exports[`atom 1.0 should generate a valid feed 1`] = `
         </contributor>
         <published>2013-07-10T23:00:00.000Z</published>
     </entry>
+    <entry>
+        <title type=\\"html\\"><![CDATA[Hello World 2]]></title>
+        <id>https://example.com/hello-world-2</id>
+        <link href=\\"https://example.com/hello-world-2\\">
+        </link>
+        <updated>2013-07-13T22:00:00.000Z</updated>
+        <summary type=\\"html\\"><![CDATA[This is another article about Hello World.]]></summary>
+        <published>2013-07-10T23:00:00.000Z</published>
+    </entry>
 </feed>"
 `;

--- a/src/__tests__/__snapshots__/json.spec.ts.snap
+++ b/src/__tests__/__snapshots__/json.spec.ts.snap
@@ -42,6 +42,14 @@ exports[`json 1 should generate a valid feed 1`] = `
                 \\"about\\": \\"just a second item extension example\\",
                 \\"dummy1\\": \\"example\\"
             }
+        },
+        {
+            \\"id\\": \\"https://example.com/hello-world-2\\",
+            \\"url\\": \\"https://example.com/hello-world-2\\",
+            \\"title\\": \\"Hello World 2\\",
+            \\"summary\\": \\"This is another article about Hello World.\\",
+            \\"date_modified\\": \\"2013-07-13T22:00:00.000Z\\",
+            \\"date_published\\": \\"2013-07-10T23:00:00.000Z\\"
         }
     ]
 }"

--- a/src/__tests__/__snapshots__/rss2.spec.ts.snap
+++ b/src/__tests__/__snapshots__/rss2.spec.ts.snap
@@ -258,6 +258,13 @@ exports[`rss 2.0 should generate a valid feed with video 1`] = `
             <category domain=\\"http://www.fool.com/cusips\\">MSFT</category>
             <enclosure url=\\"https://example.com/hello-world.mp4\\" length=\\"0\\" type=\\"video/mp4\\"/>
         </item>
+        <item>
+            <title><![CDATA[Hello World 2]]></title>
+            <link>https://example.com/hello-world-2</link>
+            <guid isPermaLink=\\"false\\">58f618d7a56f2f745291a473</guid>
+            <pubDate>Sat, 13 Jul 2013 22:00:00 GMT</pubDate>
+            <description><![CDATA[This is another article about Hello World.]]></description>
+        </item>
     </channel>
 </rss>"
 `;

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -99,6 +99,17 @@ sampleFeed.addItem({
   published,
 });
 
+sampleFeed.addItem({
+  title: "Hello World 2",
+  id: "https://example.com/hello-world-2",
+  link: "https://example.com/hello-world-2",
+  guid: "58f618d7a56f2f745291a473",
+  guidIsPermaLink: false,
+  description: "This is another article about Hello World.",
+  date: new Date("Sat, 13 Jul 2013 22:00:00 GMT"),
+  published
+});
+
 sampleFeed.addExtension({
   name: "_example_extension",
   objects: {

--- a/src/rss2.ts
+++ b/src/rss2.ts
@@ -128,6 +128,14 @@ export default (ins: Feed) => {
 
     if (entry.guid) {
       item.guid = { _text: entry.guid };
+
+      /**
+       * GUID isPermaLink
+       * https://validator.w3.org/feed/docs/error/InvalidHttpGUID.html
+       */
+       if (entry.guidIsPermaLink !== undefined) {
+        item.guid._attr = { isPermaLink: entry.guidIsPermaLink };
+      }
     } else if (entry.id) {
       item.guid = { _text: entry.id };
     } else if (entry.link) {

--- a/src/typings/index.ts
+++ b/src/typings/index.ts
@@ -9,6 +9,7 @@ export interface Item {
   category?: Category[];
 
   guid?: string;
+  guidIsPermaLink?: boolean;
 
   image?: string | Enclosure;
   audio?: string | Enclosure;


### PR DESCRIPTION
I've created this PR just to solve conflicts of https://github.com/jpmonette/feed/pull/89 created by @neopostmodern , credits of the work done go for him.

`item:guid` has to be a URL unless the `isPermaLink` attribute is set to false.
I've added this functionality targeting RSS 2.0 and updated tests (for which I need to mangle types a bit -- did these tests pass before I checked them out?)
I believe that the behavior for Atom could/should be updated in some way, because it allows non-URL `item:id` values ([Example](https://en.wikipedia.org/wiki/Atom_(Web_standard)#Example_of_an_Atom_1.0_feed)), but which wouldn't be allowed in RSS 1.0. But this would cause major infrastructure-changes I guess, wheres just adding the `isPermaLink` attribute should be non-breaking.