### PR TITLE
fix: 🐛 hub option should pushed to the array atom:link

### DIFF
--- a/src/rss2.ts
+++ b/src/rss2.ts
@@ -101,12 +101,12 @@ export default (ins: Feed) => {
     if (!base.rss.channel["atom:link"]) {
       base.rss.channel["atom:link"] = [];
     }
-    base.rss.channel["atom:link"] = {
+    base.rss.channel["atom:link"].push({
       _attributes: {
         href: sanitize(options.hub),
         rel: "hub"
       }
-    };
+    });
   }
 
   /**


### PR DESCRIPTION
RSS2 Google PubSubHubbub problem #183
https://github.com/jpmonette/feed/issues/183

Only one atom:link in RSS2 is posible at the moment.
If you have atomLink and hub option at the same time, only the last one is added to the feed.