### PR TITLE
Adds avatar to author for Json Feed

### DIFF
--- a/src/json.ts
+++ b/src/json.ts
@@ -37,6 +37,9 @@ export default (ins: Feed) => {
     if (options.author.link) {
       feed.author.url = options.author.link;
     }
+    if (options.author.avatar) {
+      feed.author.avatar = options.author.avatar;
+    }
   }
 
   extensions.map((e: Extension) => {
@@ -83,6 +86,9 @@ export default (ins: Feed) => {
       }
       if (author.link) {
         feedItem.author.url = author.link;
+      }
+      if (author.avatar) {
+        feedItem.author.avatar = author.avatar;
       }
     }
 

--- a/src/typings/index.ts
+++ b/src/typings/index.ts
@@ -36,6 +36,7 @@ export interface Author {
   name?: string;
   email?: string;
   link?: string;
+  avatar?: string;
 }
 
 export interface Category {


### PR DESCRIPTION
JSON Feed 1.1 [supports avatar links for authors](https://www.jsonfeed.org/version/1.1/). This PR adds that support.