### PR TITLE
fix: .rss2() not support Extension

### DIFF
--- a/src/__tests__/__snapshots__/rss2.spec.ts.snap
+++ b/src/__tests__/__snapshots__/rss2.spec.ts.snap
@@ -32,7 +32,19 @@ exports[`rss 2.0 should generate a valid feed 1`] = `
             <category>Grateful Dead</category>
             <category domain=\\"http://www.fool.com/cusips\\">MSFT</category>
             <enclosure url=\\"https://example.com/hello-world.jpg\\" length=\\"0\\" type=\\"image/jpg\\"/>
+            <_item_extension_1>
+                <about>just an item extension example</about>
+                <dummy1>example</dummy1>
+            </_item_extension_1>
+            <_item_extension_2>
+                <about>just a second item extension example</about>
+                <dummy1>example</dummy1>
+            </_item_extension_2>
         </item>
+        <_example_extension>
+            <about>just an extension example</about>
+            <dummy>example</dummy>
+        </_example_extension>
     </channel>
 </rss>"
 `;
@@ -69,6 +81,14 @@ exports[`rss 2.0 should generate a valid feed with audio 1`] = `
             <category>Grateful Dead</category>
             <category domain=\\"http://www.fool.com/cusips\\">MSFT</category>
             <enclosure url=\\"https://example.com/hello-world.jpg\\" length=\\"0\\" type=\\"image/jpg\\"/>
+            <_item_extension_1>
+                <about>just an item extension example</about>
+                <dummy1>example</dummy1>
+            </_item_extension_1>
+            <_item_extension_2>
+                <about>just a second item extension example</about>
+                <dummy1>example</dummy1>
+            </_item_extension_2>
         </item>
         <item>
             <title><![CDATA[Hello World]]></title>
@@ -82,6 +102,14 @@ exports[`rss 2.0 should generate a valid feed with audio 1`] = `
             <category>Grateful Dead</category>
             <category domain=\\"http://www.fool.com/cusips\\">MSFT</category>
             <enclosure length=\\"12665\\" type=\\"image/jpg\\" url=\\"https://example.com/hello-world.jpg\\"/>
+            <_item_extension_1>
+                <about>just an item extension example</about>
+                <dummy1>example</dummy1>
+            </_item_extension_1>
+            <_item_extension_2>
+                <about>just a second item extension example</about>
+                <dummy1>example</dummy1>
+            </_item_extension_2>
         </item>
         <item>
             <title><![CDATA[Hello World]]></title>
@@ -95,6 +123,14 @@ exports[`rss 2.0 should generate a valid feed with audio 1`] = `
             <category>Grateful Dead</category>
             <category domain=\\"http://www.fool.com/cusips\\">MSFT</category>
             <enclosure length=\\"12665\\" type=\\"image/jpg\\" url=\\"https://example.com/hello-world.jpg\\"/>
+            <_item_extension_1>
+                <about>just an item extension example</about>
+                <dummy1>example</dummy1>
+            </_item_extension_1>
+            <_item_extension_2>
+                <about>just a second item extension example</about>
+                <dummy1>example</dummy1>
+            </_item_extension_2>
         </item>
         <item>
             <title><![CDATA[Hello World]]></title>
@@ -108,7 +144,19 @@ exports[`rss 2.0 should generate a valid feed with audio 1`] = `
             <category>Grateful Dead</category>
             <category domain=\\"http://www.fool.com/cusips\\">MSFT</category>
             <enclosure length=\\"12665\\" type=\\"audio/mpeg\\" url=\\"https://example.com/hello-world.mp3\\"/>
+            <_item_extension_1>
+                <about>just an item extension example</about>
+                <dummy1>example</dummy1>
+            </_item_extension_1>
+            <_item_extension_2>
+                <about>just a second item extension example</about>
+                <dummy1>example</dummy1>
+            </_item_extension_2>
         </item>
+        <_example_extension>
+            <about>just an extension example</about>
+            <dummy>example</dummy>
+        </_example_extension>
     </channel>
 </rss>"
 `;
@@ -145,6 +193,14 @@ exports[`rss 2.0 should generate a valid feed with enclosure 1`] = `
             <category>Grateful Dead</category>
             <category domain=\\"http://www.fool.com/cusips\\">MSFT</category>
             <enclosure url=\\"https://example.com/hello-world.jpg\\" length=\\"0\\" type=\\"image/jpg\\"/>
+            <_item_extension_1>
+                <about>just an item extension example</about>
+                <dummy1>example</dummy1>
+            </_item_extension_1>
+            <_item_extension_2>
+                <about>just a second item extension example</about>
+                <dummy1>example</dummy1>
+            </_item_extension_2>
         </item>
         <item>
             <title><![CDATA[Hello World]]></title>
@@ -158,6 +214,14 @@ exports[`rss 2.0 should generate a valid feed with enclosure 1`] = `
             <category>Grateful Dead</category>
             <category domain=\\"http://www.fool.com/cusips\\">MSFT</category>
             <enclosure length=\\"12665\\" type=\\"image/jpg\\" url=\\"https://example.com/hello-world.jpg\\"/>
+            <_item_extension_1>
+                <about>just an item extension example</about>
+                <dummy1>example</dummy1>
+            </_item_extension_1>
+            <_item_extension_2>
+                <about>just a second item extension example</about>
+                <dummy1>example</dummy1>
+            </_item_extension_2>
         </item>
         <item>
             <title><![CDATA[Hello World]]></title>
@@ -171,7 +235,19 @@ exports[`rss 2.0 should generate a valid feed with enclosure 1`] = `
             <category>Grateful Dead</category>
             <category domain=\\"http://www.fool.com/cusips\\">MSFT</category>
             <enclosure length=\\"12665\\" type=\\"image/jpg\\" url=\\"https://example.com/hello-world.jpg\\"/>
+            <_item_extension_1>
+                <about>just an item extension example</about>
+                <dummy1>example</dummy1>
+            </_item_extension_1>
+            <_item_extension_2>
+                <about>just a second item extension example</about>
+                <dummy1>example</dummy1>
+            </_item_extension_2>
         </item>
+        <_example_extension>
+            <about>just an extension example</about>
+            <dummy>example</dummy>
+        </_example_extension>
     </channel>
 </rss>"
 `;
@@ -208,6 +284,14 @@ exports[`rss 2.0 should generate a valid feed with image properties 1`] = `
             <category>Grateful Dead</category>
             <category domain=\\"http://www.fool.com/cusips\\">MSFT</category>
             <enclosure url=\\"https://example.com/hello-world.jpg\\" length=\\"0\\" type=\\"image/jpg\\"/>
+            <_item_extension_1>
+                <about>just an item extension example</about>
+                <dummy1>example</dummy1>
+            </_item_extension_1>
+            <_item_extension_2>
+                <about>just a second item extension example</about>
+                <dummy1>example</dummy1>
+            </_item_extension_2>
         </item>
         <item>
             <title><![CDATA[Hello World]]></title>
@@ -221,7 +305,19 @@ exports[`rss 2.0 should generate a valid feed with image properties 1`] = `
             <category>Grateful Dead</category>
             <category domain=\\"http://www.fool.com/cusips\\">MSFT</category>
             <enclosure length=\\"12665\\" type=\\"image/jpg\\" url=\\"https://example.com/hello-world.jpg\\"/>
+            <_item_extension_1>
+                <about>just an item extension example</about>
+                <dummy1>example</dummy1>
+            </_item_extension_1>
+            <_item_extension_2>
+                <about>just a second item extension example</about>
+                <dummy1>example</dummy1>
+            </_item_extension_2>
         </item>
+        <_example_extension>
+            <about>just an extension example</about>
+            <dummy>example</dummy>
+        </_example_extension>
     </channel>
 </rss>"
 `;
@@ -257,6 +353,14 @@ exports[`rss 2.0 should generate a valid feed with video 1`] = `
             <category>Grateful Dead</category>
             <category domain=\\"http://www.fool.com/cusips\\">MSFT</category>
             <enclosure url=\\"https://example.com/hello-world.mp4\\" length=\\"0\\" type=\\"video/mp4\\"/>
+            <_item_extension_1>
+                <about>just an item extension example</about>
+                <dummy1>example</dummy1>
+            </_item_extension_1>
+            <_item_extension_2>
+                <about>just a second item extension example</about>
+                <dummy1>example</dummy1>
+            </_item_extension_2>
         </item>
     </channel>
 </rss>"

--- a/src/__tests__/rss2.spec.ts
+++ b/src/__tests__/rss2.spec.ts
@@ -227,4 +227,14 @@ describe("rss 2.0", () => {
     const actual = sampleFeed.rss2();
     expect(actual).toMatchSnapshot();
   });
+  it("should generate a valid feed with `addExtension`", () => {
+    sampleFeed.addExtension({
+      name: "extension_name",
+      objects: {
+        about: "just an extension example",
+      },
+    });
+    const actual = sampleFeed.rss2();
+    expect(actual).toContain("<extension_name>");
+  });
 });

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -23,8 +23,8 @@ export const sampleFeed = new Feed({
   author: {
     name: "John Doe",
     email: "johndoe@example.com",
-    link: "https://example.com/johndoe?link=sanitized&value=2"
-  }
+    link: "https://example.com/johndoe?link=sanitized&value=2",
+  },
 });
 
 sampleFeed.addCategory("Technology");
@@ -54,7 +54,7 @@ sampleFeed.addItem({
     },
     {
       name: "Joe Smith, Name Only",
-    }
+    },
   ],
   contributor: [
     {

--- a/src/rss2.ts
+++ b/src/rss2.ts
@@ -1,14 +1,14 @@
 import * as convert from "xml-js";
 import { generator } from "./config";
 import { Feed } from "./feed";
-import { Author, Category, Enclosure, Item } from "./typings";
+import { Author, Category, Enclosure, Extension, Item } from "./typings";
 import { sanitize } from "./utils";
 
 /**
  * Returns a RSS 2.0 feed
  */
 export default (ins: Feed) => {
-  const { options } = ins;
+  const { options, extensions } = ins;
   let isAtom = false;
   let isContent = false;
 
@@ -51,7 +51,7 @@ export default (ins: Feed) => {
     base.rss.channel.image = {
       title: { _text: options.title },
       url: { _text: options.image },
-      link: { _text: sanitize(options.link) }
+      link: { _text: sanitize(options.link) },
     };
   }
 
@@ -104,8 +104,8 @@ export default (ins: Feed) => {
     base.rss.channel["atom:link"] = {
       _attributes: {
         href: sanitize(options.hub),
-        rel: "hub"
-      }
+        rel: "hub",
+      },
     };
   }
 
@@ -193,6 +193,12 @@ export default (ins: Feed) => {
       item.enclosure = formatEnclosure(entry.video, "video");
     }
 
+    if (entry.extensions) {
+      entry.extensions.forEach((extension: Extension) => {
+        item[extension.name] = extension.objects;
+      });
+    }
+
     base.rss.channel.item.push(item);
   });
 
@@ -200,6 +206,12 @@ export default (ins: Feed) => {
     base.rss._attributes["xmlns:dc"] = "http://purl.org/dc/elements/1.1/";
     base.rss._attributes["xmlns:content"] = "http://purl.org/rss/1.0/modules/content/";
   }
+
+  // rss2() support `extensions`
+  if (extensions)
+    extensions.map((e: Extension) => {
+      base.rss.channel[e.name] = e.objects;
+    });
 
   if (isAtom) {
     base.rss._attributes["xmlns:atom"] = "http://www.w3.org/2005/Atom";


### PR DESCRIPTION
There is the bug that the extension data wont be shown in the return of `.rss2()`.

for instance: 
```ts
    feed.addExtension({
      name: "ext",
      objects: {
         value: 2
      },
    });
```

the `ext` data will be there in the .json1() result, but not in the result of .rss2().