### PR TITLE
Add Catogory and Enclosure types to Export

### DIFF
--- a/src/feed.ts
+++ b/src/feed.ts
@@ -1,9 +1,9 @@
 import renderAtom from "./atom1";
 import renderJSON from "./json";
 import renderRSS from "./rss2";
-import type { Author, Extension, FeedOptions, Item } from "./typings";
+import type { Author, Category, Enclosure, Extension, FeedOptions, Item } from "./typings";
 
-export type { Author, Extension, FeedOptions, Item };
+export type { Author, Category, Enclosure, Extension, FeedOptions, Item };
 
 /**
  * Class used to generate Feeds


### PR DESCRIPTION
When upgrading from `4.2.2` to `5.0.1` these 2 types (Category, Enclosure) are all of a sudden missing.