### PR TITLE
feat(rss): relax <author> tag output condition to allow name-only

### DIFF
--- a/src/rss2.ts
+++ b/src/rss2.ts
@@ -159,6 +159,8 @@ export default (ins: Feed) => {
       entry.author.map((author: Author) => {
         if (author.email && author.name) {
           item.author.push({ _text: author.email + " (" + author.name + ")" });
+        } else if (author.name) {
+          item.author.push({ _text: author.name });
         }
       });
     }


### PR DESCRIPTION
### Background

Previously, the `<author>` tag in the generated RSS 2.0 feed was only included when both the author's name and email were provided. However, in many real-world cases, authors may choose not to provide an email address. In such situations, displaying the author's name alone can still be useful for attribution and clarity.

### Changes

- Adjusted the logic to output the `<author>` tag when the author's name exists, regardless of whether the email is present.
- This improves flexibility and ensures that author information is not omitted unnecessarily.

### Impact

- Backward compatible change.
- No effect on existing behavior when both name and email are present.
- Adds support for generating `<author>` tag with name only.