### PR TITLE
fix(atom/rss): respect Enclosure.type & avoid broken auto-detection

### DIFF
--- a/src/__tests__/__snapshots__/atom1.spec.ts.snap
+++ b/src/__tests__/__snapshots__/atom1.spec.ts.snap
@@ -29,7 +29,7 @@ exports[`atom 1.0 should generate a valid feed 1`] = `
         <title type=\\"html\\"><![CDATA[Hello World]]></title>
         <id>https://example.com/hello-world?id=this&amp;that=true</id>
         <link href=\\"https://example.com/hello-world?link=sanitized&amp;value=2\\"/>
-        <link rel=\\"enclosure\\" href=\\"https://example.com/hello-world.jpg\\" type=\\"image/jpg\\" length=\\"12665\\"/>
+        <link rel=\\"enclosure\\" href=\\"https://example.com/hello-world.jpg\\" type=\\"image/jpeg\\" length=\\"12665\\"/>
         <link rel=\\"enclosure\\" href=\\"https://example.com/hello-world.jpg\\" type=\\"image/jpg\\"/>
         <updated>2013-07-13T23:00:00.000Z</updated>
         <summary type=\\"html\\"><![CDATA[This is an article about Hello World.]]></summary>

--- a/src/__tests__/atom1.enclosure.test.ts
+++ b/src/__tests__/atom1.enclosure.test.ts
@@ -1,0 +1,114 @@
+import { Feed } from "../feed";
+
+test("Atom uses explicit enclosure.type when provided", () => {
+  const feed = new Feed({
+    title: "t",
+    id: "https://example.com",
+    link: "https://example.com",
+    copyright: "c",
+  });
+
+  // Proxy URL with no file extension -> auto-detection would fail
+  const proxied = "https://wsrv.nl/?url=https%3A%2F%2Fexample.com%2Fimg.jpg&w=1000";
+
+  feed.addItem({
+    title: "post",
+    id: "https://example.com/p",
+    link: "https://example.com/p",
+    date: new Date("2025-01-01"),
+    image: { url: proxied, type: "image/jpeg" }, // <— explicit type
+  });
+
+  const xml = feed.atom1();
+  expect(xml).toContain(`rel="enclosure"`);
+  expect(xml).toContain(`href="${proxied}"`);
+  expect(xml).toContain(`type="image/jpeg"`);
+});
+
+test("Atom falls back to auto-detection when no type provided", () => {
+  const feed = new Feed({
+    title: "t",
+    id: "https://example.com",
+    link: "https://example.com",
+    copyright: "c",
+  });
+
+  feed.addItem({
+    title: "post",
+    id: "https://example.com/p",
+    link: "https://example.com/p",
+    date: new Date("2025-01-01"),
+    image: { url: "https://example.com/image.png", length: 12345 }, // no explicit type
+  });
+
+  const xml = feed.atom1();
+  expect(xml).toContain(`rel="enclosure"`);
+  expect(xml).toContain(`href="https://example.com/image.png"`);
+  expect(xml).toContain(`type="image/png"`); // auto-detected from URL
+});
+
+test("Atom handles empty string type by falling back to auto-detection", () => {
+  const feed = new Feed({
+    title: "t",
+    id: "https://example.com",
+    link: "https://example.com",
+    copyright: "c",
+  });
+
+  feed.addItem({
+    title: "post",
+    id: "https://example.com/p",
+    link: "https://example.com/p",
+    date: new Date("2025-01-01"),
+    image: { url: "https://example.com/image.webp", type: "" }, // empty type
+  });
+
+  const xml = feed.atom1();
+  expect(xml).toContain(`rel="enclosure"`);
+  expect(xml).toContain(`href="https://example.com/image.webp"`);
+  expect(xml).toContain(`type="image/webp"`); // auto-detected from URL
+});
+
+test("Atom handles video enclosures with explicit type", () => {
+  const feed = new Feed({
+    title: "t",
+    id: "https://example.com",
+    link: "https://example.com",
+    copyright: "c",
+  });
+
+  feed.addItem({
+    title: "post",
+    id: "https://example.com/p",
+    link: "https://example.com/p",
+    date: new Date("2025-01-01"),
+    video: { url: "https://example.com/video.mov", type: "video/quicktime" },
+  });
+
+  const xml = feed.atom1();
+  expect(xml).toContain(`rel="enclosure"`);
+  expect(xml).toContain(`href="https://example.com/video.mov"`);
+  expect(xml).toContain(`type="video/quicktime"`);
+});
+
+test("Atom handles audio enclosures with explicit type", () => {
+  const feed = new Feed({
+    title: "t",
+    id: "https://example.com",
+    link: "https://example.com",
+    copyright: "c",
+  });
+
+  feed.addItem({
+    title: "post",
+    id: "https://example.com/p",
+    link: "https://example.com/p",
+    date: new Date("2025-01-01"),
+    audio: { url: "https://example.com/audio.ogg", type: "audio/ogg" },
+  });
+
+  const xml = feed.atom1();
+  expect(xml).toContain(`rel="enclosure"`);
+  expect(xml).toContain(`href="https://example.com/audio.ogg"`);
+  expect(xml).toContain(`type="audio/ogg"`);
+});

--- a/src/__tests__/rss2.enclosure.test.ts
+++ b/src/__tests__/rss2.enclosure.test.ts
@@ -1,0 +1,114 @@
+import { Feed } from "../feed";
+
+test("RSS2 uses explicit enclosure.type when provided", () => {
+  const feed = new Feed({
+    title: "t",
+    id: "https://example.com",
+    link: "https://example.com",
+    copyright: "c",
+  });
+
+  // Proxy URL with no file extension -> auto-detection would fail
+  const proxied = "https://wsrv.nl/?url=https%3A%2F%2Fexample.com%2Fimg.jpg&w=1000";
+
+  feed.addItem({
+    title: "post",
+    id: "https://example.com/p",
+    link: "https://example.com/p",
+    date: new Date("2025-01-01"),
+    image: { url: proxied, type: "image/jpeg" }, // <— explicit type
+  });
+
+  const xml = feed.rss2();
+  expect(xml).toContain(`<enclosure`);
+  expect(xml).toContain(`url="${proxied}"`);
+  expect(xml).toContain(`type="image/jpeg"`);
+});
+
+test("RSS2 falls back to auto-detection when no type provided", () => {
+  const feed = new Feed({
+    title: "t",
+    id: "https://example.com",
+    link: "https://example.com",
+    copyright: "c",
+  });
+
+  feed.addItem({
+    title: "post",
+    id: "https://example.com/p",
+    link: "https://example.com/p",
+    date: new Date("2025-01-01"),
+    image: { url: "https://example.com/image.png", length: 12345 }, // no explicit type
+  });
+
+  const xml = feed.rss2();
+  expect(xml).toContain(`<enclosure`);
+  expect(xml).toContain(`url="https://example.com/image.png"`);
+  expect(xml).toContain(`type="image/png"`); // auto-detected from URL
+});
+
+test("RSS2 handles empty string type by falling back to auto-detection", () => {
+  const feed = new Feed({
+    title: "t",
+    id: "https://example.com",
+    link: "https://example.com",
+    copyright: "c",
+  });
+
+  feed.addItem({
+    title: "post",
+    id: "https://example.com/p",
+    link: "https://example.com/p",
+    date: new Date("2025-01-01"),
+    image: { url: "https://example.com/image.webp", type: "" }, // empty type
+  });
+
+  const xml = feed.rss2();
+  expect(xml).toContain(`<enclosure`);
+  expect(xml).toContain(`url="https://example.com/image.webp"`);
+  expect(xml).toContain(`type="image/webp"`); // auto-detected from URL
+});
+
+test("RSS2 handles video enclosures with explicit type", () => {
+  const feed = new Feed({
+    title: "t",
+    id: "https://example.com",
+    link: "https://example.com",
+    copyright: "c",
+  });
+
+  feed.addItem({
+    title: "post",
+    id: "https://example.com/p",
+    link: "https://example.com/p",
+    date: new Date("2025-01-01"),
+    video: { url: "https://example.com/video.mov", type: "video/quicktime" },
+  });
+
+  const xml = feed.rss2();
+  expect(xml).toContain(`<enclosure`);
+  expect(xml).toContain(`url="https://example.com/video.mov"`);
+  expect(xml).toContain(`type="video/quicktime"`);
+});
+
+test("RSS2 handles audio enclosures with explicit type", () => {
+  const feed = new Feed({
+    title: "t",
+    id: "https://example.com",
+    link: "https://example.com",
+    copyright: "c",
+  });
+
+  feed.addItem({
+    title: "post",
+    id: "https://example.com/p",
+    link: "https://example.com/p",
+    date: new Date("2025-01-01"),
+    audio: { url: "https://example.com/audio.ogg", type: "audio/ogg" },
+  });
+
+  const xml = feed.rss2();
+  expect(xml).toContain(`<enclosure`);
+  expect(xml).toContain(`url="https://example.com/audio.ogg"`);
+  expect(xml).toContain(`type="audio/ogg"`);
+});

--- a/src/atom1.ts
+++ b/src/atom1.ts
@@ -212,17 +212,22 @@ const formatAuthor = (author: Author) => {
  */
 const formatEnclosure = (enclosure: string | Enclosure, mimeCategory = "image") => {
   if (typeof enclosure === "string") {
-    const type = new URL(enclosure).pathname.split(".").slice(-1)[0];
-    return { _attributes: { rel: "enclosure", href: enclosure, type: `${mimeCategory}/${type}` } };
+    const detectedType = new URL(enclosure).pathname.split(".").slice(-1)[0];
+    return { _attributes: { rel: "enclosure", href: enclosure, type: `${mimeCategory}/${detectedType}` } };
   }
-
-  const type = new URL(enclosure.url).pathname.split(".").slice(-1)[0];
+  // For object enclosures, respect the explicit type if provided.
+  // Otherwise fall back to MIME category plus detected extension.
+  let type: string | undefined = enclosure.type;
+  if (!type || type.trim() === "") {
+    const detectedType = new URL(enclosure.url).pathname.split(".").slice(-1)[0];
+    type = `${mimeCategory}/${detectedType}`;
+  }
   return {
     _attributes: {
       rel: "enclosure",
       href: enclosure.url,
       title: enclosure.title,
-      type: `${mimeCategory}/${type}`,
+      type,
       length: enclosure.length,
     },
   };

--- a/src/rss2.ts
+++ b/src/rss2.ts
@@ -264,12 +264,22 @@ export default (ins: Feed) => {
  */
 const formatEnclosure = (enclosure: string | Enclosure, mimeCategory = "image") => {
   if (typeof enclosure === "string") {
-    const type = new URL(sanitize(enclosure)!).pathname.split(".").slice(-1)[0];
-    return { _attributes: { url: enclosure, length: 0, type: `${mimeCategory}/${type}` } };
+    const detectedType = new URL(sanitize(enclosure)!).pathname.split(".").slice(-1)[0];
+    return { _attributes: { url: enclosure, length: 0, type: `${mimeCategory}/${detectedType}` } };
   }
 
-  const type = new URL(sanitize(enclosure.url)!).pathname.split(".").slice(-1)[0];
-  return { _attributes: { length: 0, type: `${mimeCategory}/${type}`, ...enclosure } };
+  // For object enclosures, respect the explicit type if provided.
+  // Otherwise fall back to MIME category plus detected extension.
+  let type: string | undefined = enclosure.type;
+  if (!type || type.trim() === "") {
+    const detectedType = new URL(sanitize(enclosure.url)!).pathname.split(".").slice(-1)[0];
+    type = `${mimeCategory}/${detectedType}`;
+  }
+
+  // Create the attributes, ensuring computed type takes precedence over enclosure.type
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { type: _, ...otherEnclosureProps } = enclosure;
+  return { _attributes: { length: 0, type, ...otherEnclosureProps } };
 };
 
 /**


### PR DESCRIPTION
Problem

formatEnclosure in atom1.ts / rss2.ts ignored the explicit Enclosure.type and always attempted to infer a type from the URL path. With proxy URLs (e.g., wsrv.nl) there’s no extension, producing type="image//".

Changes

- Use enclosure.type when provided; otherwise, infer from URL path.

Tests

- Added a tests for atom1 and rss2.

Notes

- Backward-compatible: string URLs still get best-effort detection.
- Fixes #224.