### PR TITLE
docs: Show current default value for `generator` in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ const feed = new Feed({
   favicon: "http://example.com/favicon.ico",
   copyright: "All rights reserved 2013, John Doe",
   updated: new Date(2013, 6, 14), // optional, default = today
-  generator: "awesome", // optional, default = 'Feed for Node.js'
+  generator: "awesome", // optional, default = 'https://github.com/jpmonette/feed'
   feedLinks: {
     json: "https://example.com/json",
     atom: "https://example.com/atom"


### PR DESCRIPTION
Based on latest value from https://github.com/jpmonette/feed/blob/master/src/config/index.ts

I think it's good to default to the repo URL to allow developers of feed readers to report potential improvements and bugs in the future.