### PR TITLE
perf(rss/atom/json): Use `.forEach()` instead of `.map()` when resulting array is unused

### DIFF
--- a/src/atom1.ts
+++ b/src/atom1.ts
@@ -67,13 +67,13 @@ export default (ins: Feed) => {
 
   base.feed.category = [];
 
-  ins.categories.map((category: string) => {
+  ins.categories.forEach((category: string) => {
     base.feed.category.push({ _attributes: { term: category } });
   });
 
   base.feed.contributor = [];
 
-  ins.contributors.map((contributor: Author) => {
+  ins.contributors.forEach((contributor: Author) => {
     base.feed.contributor.push(formatAuthor(contributor));
   });
 
@@ -84,7 +84,7 @@ export default (ins: Feed) => {
   /**************************************************************************
    * "entry" nodes
    *************************************************************************/
-  ins.items.map((item: Item) => {
+  ins.items.forEach((item: Item) => {
     //
     // entry: required elements
     //
@@ -117,7 +117,7 @@ export default (ins: Feed) => {
     if (Array.isArray(item.author)) {
       entry.author = [];
 
-      item.author.map((author: Author) => {
+      item.author.forEach((author: Author) => {
         entry.author.push(formatAuthor(author));
       });
     }
@@ -134,7 +134,7 @@ export default (ins: Feed) => {
     if (Array.isArray(item.category)) {
       entry.category = [];
 
-      item.category.map((category: Category) => {
+      item.category.forEach((category: Category) => {
         entry.category.push(formatCategory(category));
       });
     }
@@ -163,7 +163,7 @@ export default (ins: Feed) => {
     if (item.contributor && Array.isArray(item.contributor)) {
       entry.contributor = [];
 
-      item.contributor.map((contributor: Author) => {
+      item.contributor.forEach((contributor: Author) => {
         entry.contributor.push(formatAuthor(contributor));
       });
     }

--- a/src/json.ts
+++ b/src/json.ts
@@ -42,7 +42,7 @@ export default (ins: Feed) => {
     }
   }
 
-  extensions.map((e: Extension) => {
+  extensions.forEach((e: Extension) => {
     feed[e.name] = e.objects;
   });
 
@@ -94,7 +94,7 @@ export default (ins: Feed) => {
 
     if (Array.isArray(item.category)) {
       feedItem.tags = [];
-      item.category.map((category: Category) => {
+      item.category.forEach((category: Category) => {
         if (category.name) {
           feedItem.tags.push(category.name);
         }
@@ -102,7 +102,7 @@ export default (ins: Feed) => {
     }
 
     if (item.extensions) {
-      item.extensions.map((e: Extension) => {
+      item.extensions.forEach((e: Extension) => {
         feedItem[e.name] = e.objects;
       });
     }

--- a/src/rss2.ts
+++ b/src/rss2.ts
@@ -67,7 +67,7 @@ export default (ins: Feed) => {
    * Channel Categories
    * https://validator.w3.org/feed/docs/rss2.html#comments
    */
-  ins.categories.map((category) => {
+  ins.categories.forEach((category) => {
     if (!base.rss.channel.category) {
       base.rss.channel.category = [];
     }
@@ -115,7 +115,7 @@ export default (ins: Feed) => {
    */
   base.rss.channel.item = [];
 
-  ins.items.map((entry: Item) => {
+  ins.items.forEach((entry: Item) => {
     const item: any = {};
 
     if (entry.title) {
@@ -156,7 +156,7 @@ export default (ins: Feed) => {
      */
     if (Array.isArray(entry.author)) {
       item.author = [];
-      entry.author.map((author: Author) => {
+      entry.author.forEach((author: Author) => {
         if (author.email && author.name) {
           item.author.push({ _text: author.email + " (" + author.name + ")" });
         }
@@ -168,7 +168,7 @@ export default (ins: Feed) => {
      */
     if (Array.isArray(entry.category)) {
       item.category = [];
-      entry.category.map((category: Category) => {
+      entry.category.forEach((category: Category) => {
         item.category.push(formatCategory(category));
       });
     }
@@ -218,7 +218,7 @@ export default (ins: Feed) => {
 
   // rss2() support `extensions`
   if (extensions)
-    extensions.map((e: Extension) => {
+    extensions.forEach((e: Extension) => {
       base.rss.channel[e.name] = e.objects;
     });
 


### PR DESCRIPTION
Existing functionality is not changed, and tests still pass.

This improves (marginally) performance by reducing unnecessary work. More importantly though, this change makes the code slightly easier to read and maintain, by explicitly using `.map()` only when `.forEach()` is not enough. This makes the intention clearer.

Fix #233