### PR TITLE
Hotfix for allowing multiple atom:link tags in the RSS2 feed

### DIFF
--- a/src/__tests__/__snapshots__/rss2.spec.ts.snap
+++ b/src/__tests__/__snapshots__/rss2.spec.ts.snap
@@ -19,6 +19,7 @@ exports[`rss 2.0 Should specify isPermaLink=false when feed item specifies a gui
         </image>
         <copyright>All rights reserved 2013, John Doe</copyright>
         <category>Technology</category>
+        <atom:link href=\\"http://example.com/sampleFeed.rss?link=sanitized&amp;value=2\\" rel=\\"self\\" type=\\"application/rss+xml\\"/>
         <atom:link href=\\"wss://example.com/\\" rel=\\"hub\\"/>
         <item>
             <title><![CDATA[Hello World]]></title>
@@ -140,6 +141,7 @@ exports[`rss 2.0 Should specify isPermaLink=false when feed item specifies a lin
         </image>
         <copyright>All rights reserved 2013, John Doe</copyright>
         <category>Technology</category>
+        <atom:link href=\\"http://example.com/sampleFeed.rss?link=sanitized&amp;value=2\\" rel=\\"self\\" type=\\"application/rss+xml\\"/>
         <atom:link href=\\"wss://example.com/\\" rel=\\"hub\\"/>
         <item>
             <title><![CDATA[Hello World]]></title>
@@ -273,6 +275,7 @@ exports[`rss 2.0 Should specify isPermaLink=false when feed item specifies an id
         </image>
         <copyright>All rights reserved 2013, John Doe</copyright>
         <category>Technology</category>
+        <atom:link href=\\"http://example.com/sampleFeed.rss?link=sanitized&amp;value=2\\" rel=\\"self\\" type=\\"application/rss+xml\\"/>
         <atom:link href=\\"wss://example.com/\\" rel=\\"hub\\"/>
         <item>
             <title><![CDATA[Hello World]]></title>
@@ -400,6 +403,7 @@ exports[`rss 2.0 should generate a valid feed 1`] = `
         </image>
         <copyright>All rights reserved 2013, John Doe</copyright>
         <category>Technology</category>
+        <atom:link href=\\"http://example.com/sampleFeed.rss?link=sanitized&amp;value=2\\" rel=\\"self\\" type=\\"application/rss+xml\\"/>
         <atom:link href=\\"wss://example.com/\\" rel=\\"hub\\"/>
         <item>
             <title><![CDATA[Hello World]]></title>
@@ -449,6 +453,7 @@ exports[`rss 2.0 should generate a valid feed with audio 1`] = `
         </image>
         <copyright>All rights reserved 2013, John Doe</copyright>
         <category>Technology</category>
+        <atom:link href=\\"http://example.com/sampleFeed.rss?link=sanitized&amp;value=2\\" rel=\\"self\\" type=\\"application/rss+xml\\"/>
         <atom:link href=\\"wss://example.com/\\" rel=\\"hub\\"/>
         <item>
             <title><![CDATA[Hello World]]></title>
@@ -561,6 +566,7 @@ exports[`rss 2.0 should generate a valid feed with enclosure 1`] = `
         </image>
         <copyright>All rights reserved 2013, John Doe</copyright>
         <category>Technology</category>
+        <atom:link href=\\"http://example.com/sampleFeed.rss?link=sanitized&amp;value=2\\" rel=\\"self\\" type=\\"application/rss+xml\\"/>
         <atom:link href=\\"wss://example.com/\\" rel=\\"hub\\"/>
         <item>
             <title><![CDATA[Hello World]]></title>
@@ -652,6 +658,7 @@ exports[`rss 2.0 should generate a valid feed with image properties 1`] = `
         </image>
         <copyright>All rights reserved 2013, John Doe</copyright>
         <category>Technology</category>
+        <atom:link href=\\"http://example.com/sampleFeed.rss?link=sanitized&amp;value=2\\" rel=\\"self\\" type=\\"application/rss+xml\\"/>
         <atom:link href=\\"wss://example.com/\\" rel=\\"hub\\"/>
         <item>
             <title><![CDATA[Hello World]]></title>
@@ -766,6 +773,7 @@ exports[`rss 2.0 should generate a valid podcast feed with audio 1`] = `
         </image>
         <copyright>All rights reserved 2013, John Doe</copyright>
         <category>Technology</category>
+        <atom:link href=\\"http://example.com/sampleFeed.rss?link=sanitized&amp;value=2\\" rel=\\"self\\" type=\\"application/rss+xml\\"/>
         <atom:link href=\\"wss://example.com/\\" rel=\\"hub\\"/>
         <item>
             <title><![CDATA[Hello World]]></title>

--- a/src/rss2.ts
+++ b/src/rss2.ts
@@ -81,15 +81,16 @@ export default (ins: Feed) => {
   const atomLink = options.feed || (options.feedLinks && options.feedLinks.rss);
   if (atomLink) {
     isAtom = true;
-    base.rss.channel["atom:link"] = [
-      {
-        _attributes: {
-          href: sanitize(atomLink),
-          rel: "self",
-          type: "application/rss+xml",
-        },
+    if (!base.rss.channel["atom:link"]) {
+      base.rss.channel["atom:link"] = [];
+    }
+    base.rss.channel["atom:link"].push({
+      _attributes: {
+        href: sanitize(atomLink),
+        rel: "self",
+        type: "application/rss+xml",
       },
-    ];
+    });
   }
 
   /**
@@ -101,12 +102,12 @@ export default (ins: Feed) => {
     if (!base.rss.channel["atom:link"]) {
       base.rss.channel["atom:link"] = [];
     }
-    base.rss.channel["atom:link"] = {
+    base.rss.channel["atom:link"].push({
       _attributes: {
         href: sanitize(options.hub),
         rel: "hub",
       },
-    };
+    });
   }
 
   /**


### PR DESCRIPTION
Hi, this is a very small hotfix for allowing multiple atom:link tags in the RSS2 feed, such as a WebSub hub link and a self link. I'm submitting the hotfix with updated test snapshots.

This same work was already made in the Atom feed in a previous fix, but wasn't updated for the RSS2 feed.

I'll be glad to help to get this merged ASAP.

Thanks!