### PR TITLE
Support `source` Attribute for Markdown Items and Others

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ console.log(feed.json1());
 | `guid`        | `string`              | RSS-specific GUID                        |
 | `description` | `string`              | Brief summary or excerpt                 |
 | `content`     | `string`              | Full content (HTML allowed)              |
-| `contentIsMarkdown`     | `boolean`              | Allows `content` to support markdown              |
+| `needsSourceNamespace`     | `boolean`              | Supports `source` add-ons (https://source.scripting.com)              |
 | `author`      | `Author[]`            | Item authors                             |
 | `contributor` | `Author[]`            | Item contributors                        |
 | `category`    | `Category[]`          | Item categories                          |

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ console.log(feed.json1());
 | `guid`        | `string`              | RSS-specific GUID                        |
 | `description` | `string`              | Brief summary or excerpt                 |
 | `content`     | `string`              | Full content (HTML allowed)              |
+| `contentIsMarkdown`     | `boolean`              | Allows `content` to support markdown              |
 | `author`      | `Author[]`            | Item authors                             |
 | `contributor` | `Author[]`            | Item contributors                        |
 | `category`    | `Category[]`          | Item categories                          |

--- a/src/__tests__/__snapshots__/rss2.spec.ts.snap
+++ b/src/__tests__/__snapshots__/rss2.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`rss 2.0 Should specify isPermaLink=false when feed item specifies a guid 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
-<rss version=\\"2.0\\" xmlns:dc=\\"http://purl.org/dc/elements/1.1/\\" xmlns:content=\\"http://purl.org/rss/1.0/modules/content/\\" xmlns:atom=\\"http://www.w3.org/2005/Atom\\">
+<rss version=\\"2.0\\" xmlns:dc=\\"http://purl.org/dc/elements/1.1/\\" xmlns:content=\\"http://purl.org/rss/1.0/modules/content/\\" xmlns:source=\\"https://source.scripting.com/\\" xmlns:atom=\\"http://www.w3.org/2005/Atom\\">
     <channel>
         <title>Feed Title</title>
         <link>http://example.com/?link=sanitized&amp;value=3</link>
@@ -125,7 +125,7 @@ exports[`rss 2.0 Should specify isPermaLink=false when feed item specifies a gui
 
 exports[`rss 2.0 Should specify isPermaLink=false when feed item specifies a link, but not an id or a guid 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
-<rss version=\\"2.0\\" xmlns:dc=\\"http://purl.org/dc/elements/1.1/\\" xmlns:content=\\"http://purl.org/rss/1.0/modules/content/\\" xmlns:atom=\\"http://www.w3.org/2005/Atom\\">
+<rss version=\\"2.0\\" xmlns:dc=\\"http://purl.org/dc/elements/1.1/\\" xmlns:content=\\"http://purl.org/rss/1.0/modules/content/\\" xmlns:source=\\"https://source.scripting.com/\\" xmlns:atom=\\"http://www.w3.org/2005/Atom\\">
     <channel>
         <title>Feed Title</title>
         <link>http://example.com/?link=sanitized&amp;value=3</link>
@@ -260,7 +260,7 @@ exports[`rss 2.0 Should specify isPermaLink=false when feed item specifies a lin
 
 exports[`rss 2.0 Should specify isPermaLink=false when feed item specifies an id 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
-<rss version=\\"2.0\\" xmlns:dc=\\"http://purl.org/dc/elements/1.1/\\" xmlns:content=\\"http://purl.org/rss/1.0/modules/content/\\" xmlns:atom=\\"http://www.w3.org/2005/Atom\\">
+<rss version=\\"2.0\\" xmlns:dc=\\"http://purl.org/dc/elements/1.1/\\" xmlns:content=\\"http://purl.org/rss/1.0/modules/content/\\" xmlns:source=\\"https://source.scripting.com/\\" xmlns:atom=\\"http://www.w3.org/2005/Atom\\">
     <channel>
         <title>Feed Title</title>
         <link>http://example.com/?link=sanitized&amp;value=3</link>
@@ -389,7 +389,7 @@ exports[`rss 2.0 Should specify isPermaLink=false when feed item specifies an id
 
 exports[`rss 2.0 should generate a valid feed 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
-<rss version=\\"2.0\\" xmlns:dc=\\"http://purl.org/dc/elements/1.1/\\" xmlns:content=\\"http://purl.org/rss/1.0/modules/content/\\" xmlns:atom=\\"http://www.w3.org/2005/Atom\\">
+<rss version=\\"2.0\\" xmlns:dc=\\"http://purl.org/dc/elements/1.1/\\" xmlns:content=\\"http://purl.org/rss/1.0/modules/content/\\" xmlns:source=\\"https://source.scripting.com/\\" xmlns:atom=\\"http://www.w3.org/2005/Atom\\">
     <channel>
         <title>Feed Title</title>
         <link>http://example.com/?link=sanitized&amp;value=3</link>
@@ -440,7 +440,7 @@ exports[`rss 2.0 should generate a valid feed 1`] = `
 
 exports[`rss 2.0 should generate a valid feed with audio 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
-<rss version=\\"2.0\\" xmlns:dc=\\"http://purl.org/dc/elements/1.1/\\" xmlns:content=\\"http://purl.org/rss/1.0/modules/content/\\" xmlns:atom=\\"http://www.w3.org/2005/Atom\\">
+<rss version=\\"2.0\\" xmlns:dc=\\"http://purl.org/dc/elements/1.1/\\" xmlns:content=\\"http://purl.org/rss/1.0/modules/content/\\" xmlns:source=\\"https://source.scripting.com/\\" xmlns:atom=\\"http://www.w3.org/2005/Atom\\">
     <channel>
         <title>Feed Title</title>
         <link>http://example.com/?link=sanitized&amp;value=3</link>
@@ -554,7 +554,7 @@ exports[`rss 2.0 should generate a valid feed with audio 1`] = `
 
 exports[`rss 2.0 should generate a valid feed with enclosure 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
-<rss version=\\"2.0\\" xmlns:dc=\\"http://purl.org/dc/elements/1.1/\\" xmlns:content=\\"http://purl.org/rss/1.0/modules/content/\\" xmlns:atom=\\"http://www.w3.org/2005/Atom\\">
+<rss version=\\"2.0\\" xmlns:dc=\\"http://purl.org/dc/elements/1.1/\\" xmlns:content=\\"http://purl.org/rss/1.0/modules/content/\\" xmlns:source=\\"https://source.scripting.com/\\" xmlns:atom=\\"http://www.w3.org/2005/Atom\\">
     <channel>
         <title>Feed Title</title>
         <link>http://example.com/?link=sanitized&amp;value=3</link>
@@ -647,7 +647,7 @@ exports[`rss 2.0 should generate a valid feed with enclosure 1`] = `
 
 exports[`rss 2.0 should generate a valid feed with image properties 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
-<rss version=\\"2.0\\" xmlns:dc=\\"http://purl.org/dc/elements/1.1/\\" xmlns:content=\\"http://purl.org/rss/1.0/modules/content/\\" xmlns:atom=\\"http://www.w3.org/2005/Atom\\">
+<rss version=\\"2.0\\" xmlns:dc=\\"http://purl.org/dc/elements/1.1/\\" xmlns:content=\\"http://purl.org/rss/1.0/modules/content/\\" xmlns:source=\\"https://source.scripting.com/\\" xmlns:atom=\\"http://www.w3.org/2005/Atom\\">
     <channel>
         <title>Feed Title</title>
         <link>http://example.com/?link=sanitized&amp;value=3</link>
@@ -786,7 +786,7 @@ exports[`rss 2.0 should generate a valid feed with video 1`] = `
 
 exports[`rss 2.0 should generate a valid podcast feed with audio 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
-<rss version=\\"2.0\\" xmlns:dc=\\"http://purl.org/dc/elements/1.1/\\" xmlns:content=\\"http://purl.org/rss/1.0/modules/content/\\" xmlns:atom=\\"http://www.w3.org/2005/Atom\\" xmlns:googleplay=\\"http://www.google.com/schemas/play-podcasts/1.0\\" xmlns:itunes=\\"http://www.itunes.com/dtds/podcast-1.0.dtd\\">
+<rss version=\\"2.0\\" xmlns:dc=\\"http://purl.org/dc/elements/1.1/\\" xmlns:content=\\"http://purl.org/rss/1.0/modules/content/\\" xmlns:source=\\"https://source.scripting.com/\\" xmlns:atom=\\"http://www.w3.org/2005/Atom\\" xmlns:googleplay=\\"http://www.google.com/schemas/play-podcasts/1.0\\" xmlns:itunes=\\"http://www.itunes.com/dtds/podcast-1.0.dtd\\">
     <channel>
         <title>Feed Title</title>
         <link>http://example.com/?link=sanitized&amp;value=3</link>
@@ -866,7 +866,7 @@ exports[`rss 2.0 should generate a valid podcast feed with audio 1`] = `
 
 exports[`rss 2.0 should sanitize enclosure url 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
-<rss version=\\"2.0\\" xmlns:dc=\\"http://purl.org/dc/elements/1.1/\\" xmlns:content=\\"http://purl.org/rss/1.0/modules/content/\\" xmlns:atom=\\"http://www.w3.org/2005/Atom\\">
+<rss version=\\"2.0\\" xmlns:dc=\\"http://purl.org/dc/elements/1.1/\\" xmlns:content=\\"http://purl.org/rss/1.0/modules/content/\\" xmlns:source=\\"https://source.scripting.com/\\" xmlns:atom=\\"http://www.w3.org/2005/Atom\\">
     <channel>
         <title>Feed Title</title>
         <link>http://example.com/?link=sanitized&amp;value=3</link>

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -26,6 +26,7 @@ export const createSampleFeed = () => {
       email: "johndoe@example.com",
       link: "https://example.com/johndoe?link=sanitized&value=2",
     },
+    needsSourceNamespace: true,
   });
 
   feed.addCategory("Technology");

--- a/src/rss2.ts
+++ b/src/rss2.ts
@@ -163,7 +163,15 @@ export default (ins: Feed) => {
 
     if (entry.content) {
       needsContentNamespace = true;
-      item["content:encoded"] = { _cdata: entry.content };
+      if (entry.markdownContent) {
+        /**
+          some feeds such as NetNewsWire supports content:markdown
+          @see https://netnewswire.blog/2025/11/05/netnewswire-for-mac-and-ios.html
+        */
+        item["content:markdown"] = { _cdata: entry.content };
+      } else {
+        item["content:encoded"] = { _cdata: entry.content };
+      }
     }
     /**
      * Item Author

--- a/src/rss2.ts
+++ b/src/rss2.ts
@@ -163,15 +163,7 @@ export default (ins: Feed) => {
 
     if (entry.content) {
       needsContentNamespace = true;
-      if (entry.contentIsMarkdown) {
-        /**
-          some feeds such as NetNewsWire supports content:markdown
-          @see https://netnewswire.blog/2025/11/05/netnewswire-for-mac-and-ios.html
-        */
-        item["content:markdown"] = { _cdata: entry.content };
-      } else {
-        item["content:encoded"] = { _cdata: entry.content };
-      }
+      item["content:encoded"] = { _cdata: entry.content };
     }
     /**
      * Item Author
@@ -239,6 +231,10 @@ export default (ins: Feed) => {
   if (needsContentNamespace) {
     base.rss._attributes["xmlns:dc"] = "http://purl.org/dc/elements/1.1/";
     base.rss._attributes["xmlns:content"] = "http://purl.org/rss/1.0/modules/content/";
+  }
+
+  if (options.needsSourceNamespace) {
+    base.rss._attributes["xmlns:source"] = "https://source.scripting.com/";
   }
 
   // rss2() support `extensions`

--- a/src/rss2.ts
+++ b/src/rss2.ts
@@ -163,7 +163,7 @@ export default (ins: Feed) => {
 
     if (entry.content) {
       needsContentNamespace = true;
-      if (entry.markdownContent) {
+      if (entry.contentIsMarkdown) {
         /**
           some feeds such as NetNewsWire supports content:markdown
           @see https://netnewswire.blog/2025/11/05/netnewswire-for-mac-and-ios.html

--- a/src/typings/index.ts
+++ b/src/typings/index.ts
@@ -6,7 +6,6 @@ export interface Item {
 
   description?: string;
   content?: string;
-  contentIsMarkdown?: boolean;
   category?: Category[];
 
   guid?: string;

--- a/src/typings/index.ts
+++ b/src/typings/index.ts
@@ -6,7 +6,7 @@ export interface Item {
 
   description?: string;
   content?: string;
-  markdownContent?: boolean;
+  contentIsMarkdown?: boolean;
   category?: Category[];
 
   guid?: string;

--- a/src/typings/index.ts
+++ b/src/typings/index.ts
@@ -6,6 +6,7 @@ export interface Item {
 
   description?: string;
   content?: string;
+  markdownContent?: boolean;
   category?: Category[];
 
   guid?: string;


### PR DESCRIPTION
## Description

Fixes https://github.com/jpmonette/feed/issues/244

This PR adds the ability to add markdown-supported items, which can be parsed by popular feeds such as NetNewsWire: https://netnewswire.blog/2025/11/05/netnewswire-for-mac-and-ios.html

The problem is that while I can add `<source:markdown />` elements via the `extensions` option, the XML will fail because the `source` attribute was not declared at the top-level, so adding `source:markdown` doesn't actually work

`source` is a namespace described here: https://source.scripting.com/