### PR TITLE
fix(atom): escape & in category attribute values

### DIFF
--- a/src/__tests__/atom1.spec.ts
+++ b/src/__tests__/atom1.spec.ts
@@ -41,4 +41,26 @@ describe("atom 1.0", () => {
     expect(actual).toMatchSnapshot();
     expect(actual).toContain('<link rel="enclosure" href="https://example.com/hello&amp;world.png"');
   });
+
+  it("should escape & in category attributes", () => {
+    const feed = new Feed({
+      title: "Feed Title",
+      id: "http://example.com/",
+      link: "http://example.com/",
+      updated,
+    });
+    feed.addCategory("Arts & Crafts");
+    feed.addItem({
+      title: "Hello World",
+      link: "http://example.org/2013/12/14",
+      date: updated,
+      category: [{ name: "R&D", scheme: "https://example.com/s?a=1&b=2" }],
+    });
+    const actual = feed.atom1();
+    // unlike a text node, xml-js does not escape `&` inside an attribute value,
+    // so it must be escaped before being handed to the serializer
+    expect(actual).toContain('<category term="Arts &amp; Crafts"/>');
+    expect(actual).toContain('<category label="R&amp;D" scheme="https://example.com/s?a=1&amp;b=2"/>');
+    expect(actual).not.toContain("Arts & Crafts");
+  });
 });

--- a/src/atom1.ts
+++ b/src/atom1.ts
@@ -82,7 +82,7 @@ export default (ins: Feed) => {
   base.feed.category = [];
 
   ins.categories.forEach((category: string) => {
-    base.feed.category.push({ _attributes: { term: category } });
+    base.feed.category.push({ _attributes: { term: sanitize(category) } });
   });
 
   base.feed.contributor = [];
@@ -253,9 +253,9 @@ const formatCategory = (category: Category) => {
 
   return {
     _attributes: {
-      label: name,
-      scheme,
-      term,
+      label: sanitize(name),
+      scheme: sanitize(scheme),
+      term: sanitize(term),
     },
   };
 };


### PR DESCRIPTION
The Atom renderer puts category values into attributes (`<category term="..."/>` for feed-level categories, and `label`/`scheme`/`term` for item categories) and hands them to `xml-js` unescaped.

`xml-js` escapes `&` inside element text but not inside attribute values, so a category containing an ampersand produces non-well-formed XML:

```js
feed.addCategory("Arts & Crafts");

feed.atom1(); // <category term="Arts & Crafts"/>   raw &, rejected by strict XML parsers
feed.rss2();  // <category>Arts &amp; Crafts</category>   escaped, valid
```

The RSS2 renderer already escapes the same value because it emits the category as element text, where `xml-js` does escape `&`. So the two formats disagree for identical input, and the Atom output is invalid.

This applies the existing `sanitize()` helper to the category attributes, the same approach used for enclosure URLs in #228. Feed-level snapshots are unchanged because the sample categories contain no `&`. Added a test covering the feed-level `term` and the item-level `label`/`scheme`.
