### PR TITLE
feat: allow omitting <generator> via generator: false

### DIFF
--- a/src/__tests__/atom1.spec.ts
+++ b/src/__tests__/atom1.spec.ts
@@ -41,4 +41,29 @@ describe("atom 1.0", () => {
     expect(actual).toMatchSnapshot();
     expect(actual).toContain('<link rel="enclosure" href="https://example.com/hello&amp;world.png"');
   });
+
+  it("should emit the default generator when none is provided", () => {
+    const feed = new Feed({ title: "Feed Title", id: "https://example.com/", link: "https://example.com/" });
+    expect(feed.atom1()).toContain("<generator>https://github.com/jpmonette/feed</generator>");
+  });
+
+  it("should emit a custom generator when provided", () => {
+    const feed = new Feed({
+      title: "Feed Title",
+      id: "https://example.com/",
+      link: "https://example.com/",
+      generator: "my-site",
+    });
+    expect(feed.atom1()).toContain("<generator>my-site</generator>");
+  });
+
+  it("should omit the generator element when generator is false", () => {
+    const feed = new Feed({
+      title: "Feed Title",
+      id: "https://example.com/",
+      link: "https://example.com/",
+      generator: false,
+    });
+    expect(feed.atom1()).not.toContain("<generator>");
+  });
 });

--- a/src/__tests__/rss2.spec.ts
+++ b/src/__tests__/rss2.spec.ts
@@ -364,4 +364,29 @@ describe("rss 2.0", () => {
     expect(actual).toMatchSnapshot();
     expect(actual).toContain('<enclosure length="0" type="image/png" url="https://example.com/hello&amp;world.png"/>');
   });
+
+  it("should emit the default generator when none is provided", () => {
+    const feed = new Feed({ title: "Feed Title", id: "https://example.com/", link: "https://example.com/" });
+    expect(feed.rss2()).toContain("<generator>https://github.com/jpmonette/feed</generator>");
+  });
+
+  it("should emit a custom generator when provided", () => {
+    const feed = new Feed({
+      title: "Feed Title",
+      id: "https://example.com/",
+      link: "https://example.com/",
+      generator: "my-site",
+    });
+    expect(feed.rss2()).toContain("<generator>my-site</generator>");
+  });
+
+  it("should omit the generator element when generator is false", () => {
+    const feed = new Feed({
+      title: "Feed Title",
+      id: "https://example.com/",
+      link: "https://example.com/",
+      generator: false,
+    });
+    expect(feed.rss2()).not.toContain("<generator>");
+  });
 });

--- a/src/atom1.ts
+++ b/src/atom1.ts
@@ -19,7 +19,7 @@ export default (ins: Feed) => {
       id: options.id,
       title: options.title,
       updated: options.updated ? options.updated.toISOString() : new Date().toISOString(),
-      generator: sanitize(options.generator ?? generator),
+      ...(options.generator === false ? {} : { generator: sanitize(options.generator ?? generator) }),
     },
   };
 

--- a/src/rss2.ts
+++ b/src/rss2.ts
@@ -23,7 +23,7 @@ export default (ins: Feed) => {
         description: { _text: options.description ?? "" },
         lastBuildDate: { _text: options.updated ? options.updated.toUTCString() : new Date().toUTCString() },
         docs: { _text: options.docs ? options.docs : "https://validator.w3.org/feed/docs/rss2.html" },
-        generator: { _text: options.generator ?? generator },
+        ...(options.generator === false ? {} : { generator: { _text: options.generator ?? generator } }),
       },
     },
   };

--- a/src/typings/index.ts
+++ b/src/typings/index.ts
@@ -50,7 +50,11 @@ export interface FeedOptions {
   id?: string;
   title: string;
   updated?: Date;
-  generator?: string;
+  /**
+   * Feed generator. Defaults to the library's URL.
+   * Pass `false` to omit the `<generator>` element entirely.
+   */
+  generator?: string | false;
   language?: string;
   ttl?: number;
   stylesheet?: string;


### PR DESCRIPTION
Currently `generator` only accepts a string and always falls back to the
library URL, so there's no way to remove the <generator> element. Passing
`false` leaks into RSS output as <generator>false</generator> and is
silently ignored in Atom.

This widens FeedOptions.generator to `string | false` and skips the
element entirely when `false`, for both RSS 2.0 and Atom 1.0. Default and
custom-string behaviour is unchanged; existing snapshots pass untouched.
Added unit tests covering default / custom / omitted cases for both formats.

Closes #250