### PR TITLE
feat: add docs, allow URLs & more

### DIFF
--- a/src/atom1.ts
+++ b/src/atom1.ts
@@ -23,7 +23,7 @@ export default (ins: Feed) => {
     base._instruction = {
       "xml-stylesheet": {
         _attributes: {
-          href: options.stylesheet,
+          href: sanitizeUrl(options.stylesheet),
           type: "text/xsl",
         },
       },
@@ -57,11 +57,11 @@ export default (ins: Feed) => {
   }
 
   if (options.image) {
-    base.feed.logo = options.image;
+    base.feed.logo = sanitizeUrl(options.image);
   }
 
   if (options.favicon) {
-    base.feed.icon = options.favicon;
+    base.feed.icon = sanitizeUrl(options.favicon);
   }
 
   if (options.copyright) {
@@ -85,7 +85,7 @@ export default (ins: Feed) => {
   ins.items.forEach((item: Item) => {
     const entry: convert.ElementCompact = {
       title: { _attributes: { type: "html" }, _cdata: item.title },
-      id: sanitizeUrl(item.id ?? item.link),
+      id: sanitize(item.id) ?? sanitizeUrl(item.link),
       link: [{ _attributes: { href: sanitizeUrl(item.link) } }],
       updated: item.date.toISOString(),
     };
@@ -105,17 +105,15 @@ export default (ins: Feed) => {
     }
 
     if (Array.isArray(item.author)) {
-      entry.author = [];
-
       item.author.forEach((author: Author) => {
+        if (!entry.author) entry.author = [];
         entry.author.push(formatAuthor(author));
       });
     }
 
     if (Array.isArray(item.category)) {
-      entry.category = [];
-
       item.category.forEach((category: Category) => {
+        if (!entry.category) entry.category = [];
         entry.category.push(formatCategory(category));
       });
     }

--- a/src/json.ts
+++ b/src/json.ts
@@ -1,5 +1,6 @@
 import type { Feed } from "./feed";
 import type { Category, Extension, Item } from "./typings";
+import { sanitize, sanitizeUrl } from "./utils";
 
 interface JsonFeedAuthor {
   name?: string;
@@ -39,14 +40,15 @@ export default (ins: Feed) => {
   const feed: JsonFeed = {
     version: "https://jsonfeed.org/version/1",
     title: options.title,
+    items: []
   };
 
   if (options.link) {
-    feed.home_page_url = options.link;
+    feed.home_page_url = sanitizeUrl(options.link);
   }
 
   if (options.feedLinks?.json) {
-    feed.feed_url = options.feedLinks.json;
+    feed.feed_url = sanitizeUrl(options.feedLinks.json);
   }
 
   if (options.description) {
@@ -54,7 +56,7 @@ export default (ins: Feed) => {
   }
 
   if (options.image) {
-    feed.icon = options.image;
+    feed.icon = sanitizeUrl(options.image);
   }
 
   if (options.author) {
@@ -63,7 +65,7 @@ export default (ins: Feed) => {
       feed.author.name = options.author.name;
     }
     if (options.author.link) {
-      feed.author.url = options.author.link;
+      feed.author.url = sanitizeUrl(options.author.link);
     }
     if (options.author.avatar) {
       feed.author.avatar = options.author.avatar;
@@ -76,11 +78,11 @@ export default (ins: Feed) => {
 
   feed.items = items.map((item: Item) => {
     const feedItem: JsonFeedItem = {
-      id: item.id,
+      id: sanitize(item.id) ?? sanitizeUrl(item.link),
       content_html: item.content ?? item.description,
     };
     if (item.link) {
-      feedItem.url = item.link;
+      feedItem.url = sanitizeUrl(item.link);
     }
     if (item.title) {
       feedItem.title = item.title;
@@ -90,7 +92,8 @@ export default (ins: Feed) => {
     }
 
     if (item.image) {
-      feedItem.image = typeof item.image === "string" ? item.image : item.image.url;
+      feedItem.image =
+        typeof item.image === "string" ? item.image : sanitizeUrl(item.image.url);
     }
 
     if (item.date) {
@@ -100,24 +103,24 @@ export default (ins: Feed) => {
       feedItem.date_published = item.published.toISOString();
     }
 
-    if (item.author) {
-      const author = Array.isArray(item.author) ? item.author[0] : item.author;
+    if (Array.isArray(item.author)) {
+      const author = item.author[0];
       feedItem.author = {};
-      if (author.name) {
+      if (author?.name) {
         feedItem.author.name = author.name;
       }
-      if (author.link) {
-        feedItem.author.url = author.link;
+      if (author?.link) {
+        feedItem.author.url = sanitizeUrl(author.link);
       }
-      if (author.avatar) {
+      if (author?.avatar) {
         feedItem.author.avatar = author.avatar;
       }
     }
 
     if (Array.isArray(item.category)) {
-      feedItem.tags = [];
       item.category.forEach((category: Category) => {
         if (category.name) {
+          if (!feedItem.tags) feedItem.tags = [];
           feedItem.tags.push(category.name);
         }
       });

--- a/src/json.ts
+++ b/src/json.ts
@@ -92,8 +92,7 @@ export default (ins: Feed) => {
     }
 
     if (item.image) {
-      feedItem.image =
-        typeof item.image === "string" ? item.image : sanitizeUrl(item.image.url);
+      feedItem.image = typeof item.image === "string" ? item.image : sanitizeUrl(item.image.url);
     }
 
     if (item.date) {

--- a/src/json.ts
+++ b/src/json.ts
@@ -37,18 +37,17 @@ interface JsonFeed {
 export default (ins: Feed) => {
   const { options, items, extensions } = ins;
 
-  const feed: JsonFeed = {
+  const feed: Partial<JsonFeed> = {
     version: "https://jsonfeed.org/version/1",
     title: options.title,
-    items: []
   };
 
   if (options.link) {
-    feed.home_page_url = sanitizeUrl(options.link);
+    feed.home_page_url = sanitizeUrl(options.link, false);
   }
 
   if (options.feedLinks?.json) {
-    feed.feed_url = sanitizeUrl(options.feedLinks.json);
+    feed.feed_url = sanitizeUrl(options.feedLinks.json, false);
   }
 
   if (options.description) {
@@ -56,7 +55,7 @@ export default (ins: Feed) => {
   }
 
   if (options.image) {
-    feed.icon = sanitizeUrl(options.image);
+    feed.icon = sanitizeUrl(options.image, false);
   }
 
   if (options.author) {
@@ -65,7 +64,7 @@ export default (ins: Feed) => {
       feed.author.name = options.author.name;
     }
     if (options.author.link) {
-      feed.author.url = sanitizeUrl(options.author.link);
+      feed.author.url = sanitizeUrl(options.author.link, false);
     }
     if (options.author.avatar) {
       feed.author.avatar = options.author.avatar;
@@ -78,11 +77,11 @@ export default (ins: Feed) => {
 
   feed.items = items.map((item: Item) => {
     const feedItem: JsonFeedItem = {
-      id: sanitize(item.id) ?? sanitizeUrl(item.link),
+      id: item.id ?? sanitizeUrl(item.link, false),
       content_html: item.content ?? item.description,
     };
     if (item.link) {
-      feedItem.url = sanitizeUrl(item.link);
+      feedItem.url = sanitizeUrl(item.link, false);
     }
     if (item.title) {
       feedItem.title = item.title;
@@ -92,7 +91,7 @@ export default (ins: Feed) => {
     }
 
     if (item.image) {
-      feedItem.image = typeof item.image === "string" ? item.image : sanitizeUrl(item.image.url);
+      feedItem.image = typeof item.image === "string" ? item.image : sanitizeUrl(item.image.url, false);
     }
 
     if (item.date) {
@@ -109,7 +108,7 @@ export default (ins: Feed) => {
         feedItem.author.name = author.name;
       }
       if (author?.link) {
-        feedItem.author.url = sanitizeUrl(author.link);
+        feedItem.author.url = sanitizeUrl(author.link, false);
       }
       if (author?.avatar) {
         feedItem.author.avatar = author.avatar;

--- a/src/rss2.ts
+++ b/src/rss2.ts
@@ -19,7 +19,7 @@ export default (ins: Feed) => {
         link: { _text: sanitizeUrl(options.link) },
         description: { _text: options.description ?? "" },
         lastBuildDate: { _text: options.updated ? options.updated.toUTCString() : new Date().toUTCString() },
-        docs: { _text: options.docs ?? "https://validator.w3.org/feed/docs/rss2.html" },
+        docs: { _text: sanitizeUrl(options.docs) ?? "https://validator.w3.org/feed/docs/rss2.html" },
         ...(options.generator === false ? {} : { generator: { _text: options.generator ?? generator } }),
       },
     },
@@ -29,7 +29,7 @@ export default (ins: Feed) => {
     base._instruction = {
       "xml-stylesheet": {
         _attributes: {
-          href: options.stylesheet,
+          href: sanitizeUrl(options.stylesheet),
           type: "text/xsl",
         },
       },
@@ -49,7 +49,7 @@ export default (ins: Feed) => {
   if (options.image) {
     base.rss.channel.image = {
       title: { _text: options.title },
-      url: { _text: options.image },
+      url: { _text: sanitizeUrl(options.image) },
       link: { _text: sanitizeUrl(options.link) },
     };
   }
@@ -111,7 +111,10 @@ export default (ins: Feed) => {
     } else if (entry.id) {
       item.guid = { _text: entry.id, _attributes: { isPermaLink: false } };
     } else if (entry.link) {
-      item.guid = { _text: sanitizeUrl(entry.link), _attributes: { isPermaLink: true } };
+      item.guid = {
+        _text: sanitizeUrl(entry.link),
+        _attributes: { isPermaLink: true },
+      };
     }
 
     if (entry.date) {
@@ -143,8 +146,8 @@ export default (ins: Feed) => {
     }
 
     if (Array.isArray(entry.category)) {
-      item.category = [];
       entry.category.forEach((category: Category) => {
+        if (!item.category) item.category = [];
         item.category.push(formatCategory(category));
       });
     }
@@ -160,7 +163,7 @@ export default (ins: Feed) => {
     if (entry.audio) {
       const duration =
         options.podcast && typeof entry.audio !== "string" && entry.audio.duration ? entry.audio.duration : undefined;
-      if (duration) {
+      if (duration && typeof entry.audio !== "string") {
         entry.audio.duration = undefined;
       }
       item.enclosure = formatEnclosure(entry.audio, "audio");

--- a/src/rss2.ts
+++ b/src/rss2.ts
@@ -111,10 +111,7 @@ export default (ins: Feed) => {
     } else if (entry.id) {
       item.guid = { _text: entry.id, _attributes: { isPermaLink: false } };
     } else if (entry.link) {
-      item.guid = {
-        _text: sanitizeUrl(entry.link),
-        _attributes: { isPermaLink: true },
-      };
+      item.guid = { _text: sanitizeUrl(entry.link), _attributes: { isPermaLink: true } };
     }
 
     if (entry.date) {

--- a/src/typings/index.ts
+++ b/src/typings/index.ts
@@ -1,86 +1,293 @@
 export interface Item {
+  /**
+   * Item title
+   */
   title: string;
+  /**
+   * Unique identifier (Atom/JSON). Fallbacks to the `link` if not provided.
+   */
   id?: string;
-  link: string;
+  /**
+   * URL to the item
+   */
+  link: string | URL;
+  /**
+   * Last modified/updated date
+   */
   date: Date;
 
+  /**
+   * Brief summary or excerpt
+   * @default undefined
+   */
   description?: string;
+  /**
+   * Full content (HTML allowed)
+   */
   content?: string;
+  /**
+   * Item categories
+   * @default undefined
+   */
   category?: Category[];
 
+  /**
+   * RSS-specific GUID. Fallbacks to the `id` or the `link` if not provided.
+   * @default undefined
+   */
   guid?: string;
 
+  /**
+   * Image attachment
+   * @default undefined
+   */
   image?: string | Enclosure;
+  /**
+   * Audio attachment
+   * @default undefined
+   */
   audio?: string | Enclosure;
+  /**
+   * Video attachment
+   * @default undefined
+   */
   video?: string | Enclosure;
+  /**
+   * Generic media enclosure
+   * @default undefined
+   */
   enclosure?: Enclosure;
 
+  /**
+   * Item authors
+   * @default undefined
+   */
   author?: Author[];
+  /**
+   * Item contributors
+   * @default undefined
+   */
   contributor?: Author[];
 
+  /**
+   * Original publication date
+   * @default undefined
+   */
   published?: Date;
+  /**
+   * Item copyright notice
+   * @default undefined
+   */
   copyright?: string;
 
+  /**
+   * Custom extensions
+   * @default undefined
+   */
   extensions?: Extension[];
 }
 
 export interface Enclosure {
-  url: string;
+  /**
+   * Enclosure URL
+   */
+  url: string | URL;
+  /**
+   * MIME type
+   * @example "audio/mpeg"
+   * @default undefined
+   */
   type?: string;
+  /**
+   * File size in bytes
+   * @default undefined
+   */
   length?: number;
+  /**
+   * Enclosure title
+   * @default undefined
+   */
   title?: string;
+  /**
+   * Duration in seconds (for podcasts)
+   * @default undefined
+   */
   duration?: number;
 }
 
 export interface Author {
+  /**
+   * Author name
+   * @default undefined
+   */
   name?: string;
+  /**
+   * Author email
+   * @default undefined
+   */
   email?: string;
-  link?: string;
+  /**
+   * Author link
+   * @default undefined
+   */
+  link?: string | URL;
+  /**
+   * Author avator (only used in JSON feed)
+   * @default undefined
+   */
   avatar?: string;
 }
 
 export interface Category {
+  /**
+   * Category name
+   * @default undefined
+   */
   name?: string;
+  /**
+   * Category domain (RSS-only)
+   * @default undefined
+   */
   domain?: string;
+  /**
+   * Category scheme (Atom-only)
+   * @default undefined
+   */
   scheme?: string;
+  /**
+   * Category term (Atom-only)
+   * @default undefined
+   */
   term?: string;
 }
 
 export interface FeedOptions {
+  /**
+   * Feed identifier (required for Atom)
+   * @default undefined
+   */
   id?: string;
+  /**
+   * Feed title
+   */
   title: string;
+  /**
+   * Last update date
+   * @default new Date()
+   */
   updated?: Date;
   /**
    * Feed generator. Defaults to the library's URL.
    * Pass `false` to omit the `<generator>` element entirely.
+   * @default "https://github.com/jpmonette/feed"
    */
   generator?: string | false;
+  /**
+   * Language code
+   * @example "en"
+   * @example "fr-CA"
+   * @default undefined
+   */
   language?: string;
+  /**
+   * Time to live in minutes
+   * @default undefined
+   */
   ttl?: number;
-  stylesheet?: string;
+  /**
+   * URL to an XSL stylesheet
+   * @default undefined
+   */
+  stylesheet?: string | URL;
 
-  feed?: string;
+  /**
+   * Self-referencing feed URL
+   * @default undefined
+   */
+  feed?: string | URL;
+  /**
+   * Links to other feed formats
+   * @default undefined
+   */
   feedLinks?: {
-    rss?: string;
-    atom?: string;
-    json?: string;
-    [key: string]: string | undefined;
+    /**
+     * RSS feed alternate URL. Prioritizes `feed` string value.
+     * @default undefined
+     */
+    rss?: string | URL;
+    /**
+     * Atom feed alternate URL. Prioritizes `feed` string value.
+     * @default undefined
+     */
+    atom?: string | URL;
+    /**
+     * JSON feed alternate URL
+     * @default undefined
+     */
+    json?: string | URL;
+    [key: string]: string | URL | undefined;
   };
-  hub?: string;
-  docs?: string;
+  /**
+   * WebSub/PubSubHubbub hub URL
+   * @default undefined
+   */
+  hub?: string | URL;
+  /**
+   * RSS specification docs URL, only used for RSS outputs
+   * @default "https://validator.w3.org/feed/docs/rss2.html"
+   */
+  docs?: string | URL;
 
+  /**
+   * Enable iTunes/Google podcast extensions
+   * @default undefined
+   */
   podcast?: boolean;
+  /**
+   * Podcast category name
+   * @default undefined
+   */
   category?: string;
 
+  /**
+   * Feed author
+   * @default undefined
+   */
   author?: Author;
-  link?: string;
+  /**
+   * URL to the feed's website
+   * @default undefined
+   */
+  link?: string | URL;
+  /**
+   * Feed description/subtitle
+   * @default undefined
+   */
   description?: string;
-  image?: string;
-  favicon?: string;
+  /**
+   * URL to feed image/logo
+   * @default undefined
+   */
+  image?: string | URL;
+  /**
+   * URL to feed favicon
+   * @default undefined
+   */
+  favicon?: string | URL;
+  /**
+   * Copyright notice
+   * @default undefined
+   */
   copyright?: string;
 }
 
 export interface Extension {
+  /**
+   * Extension name
+   */
   name: string;
+  /**
+   * Extension objects
+   */
   objects: Record<string, unknown>;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,10 +9,10 @@ export function sanitize(text: string | undefined): string | undefined {
   return escapeAmp(text);
 }
 
-export function sanitizeUrl(url: string): string;
-export function sanitizeUrl(url: string | undefined): string | undefined;
-export function sanitizeUrl(url: string | undefined): string | undefined {
+export function sanitizeUrl(url: string | URL): string;
+export function sanitizeUrl(url: string | URL | undefined): string | undefined;
+export function sanitizeUrl(url: string | URL | undefined): string | undefined {
   if (url === undefined) return undefined;
-  const parsed = new URL(url);
+  const parsed = typeof url === "string" ? new URL(url) : url;
   return escapeAmp(parsed.toString());
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,10 +9,10 @@ export function sanitize(text: string | undefined): string | undefined {
   return escapeAmp(text);
 }
 
-export function sanitizeUrl(url: string | URL): string;
-export function sanitizeUrl(url: string | URL | undefined): string | undefined;
-export function sanitizeUrl(url: string | URL | undefined): string | undefined {
+export function sanitizeUrl(url: string | URL, xml?: boolean): string;
+export function sanitizeUrl(url: string | URL | undefined, xml?: boolean): string | undefined;
+export function sanitizeUrl(url: string | URL | undefined, xml = true): string | undefined {
   if (url === undefined) return undefined;
   const parsed = typeof url === "string" ? new URL(url) : url;
-  return escapeAmp(parsed.toString());
+  return xml ? escapeAmp(parsed.toString()) : parsed.toString();
 }


### PR DESCRIPTION
Thanks for this library! I primarily wanted to fix the "id being parsed as a URL" issue and add docs to avoid having to open GitHub to understand the library, but my docs adjustments led to further (non-breaking) improvements.
I can understand if it's too much for one PR to review; don't hesitate if you want me to split it up. I'm reactive to feedback!

#### Changes

- Add README-originated doc to user-facing properties
- Allow using `URL` in addition to `string` where relevant
- Sanitize URLs in more places, improving behavior consistency
- Fix item ID being parsed as a URL since v6
- Fix empty author arrays throwing